### PR TITLE
removed docker-compose down - because with run --rm will do the same

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ node {
     stage ("Test") {
         tryStep "Test",  {
                 sh "docker-compose -p atlas -f .jenkins/docker-compose.yml build"
-                sh "docker-compose -p atlas -f .jenkins/docker-compose.yml run -u root atlas npm test"
+                sh "docker-compose -p atlas -f .jenkins/docker-compose.yml run --rm -u root atlas npm test"
         }
     }
 


### PR DESCRIPTION
added --rm so that the docker-compose down could be removed, This was already done