### PR TITLE
[tg-1601] Leaflet upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,7 +26,7 @@ node {
     stage ("Test") {
         tryStep "Test",  {
                 sh "docker-compose -p atlas -f .jenkins/docker-compose.yml build"
-                sh "docker-compose -p atlas -f .jenkins/docker-compose.yml run -u root atlas npm test"
+                sh "docker-compose -p atlas -f .jenkins/docker-compose.yml run --rm -u root atlas npm test"
         }
     }
 

--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "d3": "^3.5.17",
     "leaflet": "^1.0.0",
     "leaflet.wms": "~0.1.0",
-    "leaflet-measure": "2.0.2",
+    "leaflet-measure": "^2.0.5",
     "leaflet-rotatedmarker": "https://unpkg.com/leaflet-rotatedmarker/leaflet.rotatedMarker.js",
     "marzipano": "https://github.com/DatapuntAmsterdam/marzipano.git#master",
     "proj4": "*",

--- a/bower.json
+++ b/bower.json
@@ -8,9 +8,9 @@
     "angular-sanitize": "^1.5.7",
     "bbga_visualisatie_d3": "https://github.com/DatapuntAmsterdam/bbga_visualisatie_d3.git",
     "d3": "^3.5.17",
-    "leaflet": "https://github.com/DatapuntAmsterdam/datapunt_leaflet.git#master",
+    "leaflet": "^1.0.0",
     "leaflet.wms": "~0.1.0",
-    "leaflet-measure": "^2.0.2",
+    "leaflet-measure": "2.0.2",
     "leaflet-rotatedmarker": "https://unpkg.com/leaflet-rotatedmarker/leaflet.rotatedMarker.js",
     "marzipano": "https://github.com/DatapuntAmsterdam/marzipano.git#master",
     "proj4": "*",
@@ -19,5 +19,8 @@
   },
   "devDependencies": {
     "angular-mocks": "^1.5.7"
+  },
+  "resolutions": {
+    "leaflet": "^1.0.0"
   }
 }

--- a/grunt/bower-concat.js
+++ b/grunt/bower-concat.js
@@ -1,7 +1,8 @@
 module.exports = {
     js: {
         mainFiles: {
-            'angular-i18n': ['angular-locale_nl-nl.js']
+            'angular-i18n': ['angular-locale_nl-nl.js'],
+            leaflet: ['dist/leaflet.js', 'dist/leaflet.css']
         },
         dest: {
             js: 'build/temp/bower_components.js'

--- a/grunt/copy.js
+++ b/grunt/copy.js
@@ -34,7 +34,7 @@ module.exports = {
     bower_leaflet_images: {
         files: [
             {
-                cwd: 'bower_components/leaflet/images',
+                cwd: 'bower_components/leaflet/dist/images',
                 src: [
                     '**/*.png'
                 ],


### PR DESCRIPTION
Now using Leaflet 1.0.0 instead of our self hosted variant of an old release candidate.