### PR TITLE
Add Nginx logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,9 @@ RUN grunt build-release \
 
 COPY default.conf /etc/nginx/conf.d/
 RUN rm /etc/nginx/sites-enabled/default
+
+# forward request and error logs to docker log collector
+RUN ln -sf /dev/stdout /var/log/nginx/access.log \
+	&& ln -sf /dev/stderr /var/log/nginx/error.log
+
 CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
Using the same way the official Nginx image does its logging to
stdout/stderr:

https://github.com/nginxinc/docker-nginx/blob/0dd9ef6a337474293b5e36c95a85da99b11e1a0a/mainline/jessie/Dockerfile

Now all nginx logs are forwarded to Kibana, happiness ensues.