### PR TITLE
Taiga 1795 Pano popje centreren

### DIFF
--- a/modules/atlas/services/redux/reducers/map-reducers.factory.js
+++ b/modules/atlas/services/redux/reducers/map-reducers.factory.js
@@ -15,6 +15,7 @@
         reducers[ACTIONS.MAP_REMOVE_OVERLAY] = mapRemoveOverlayReducer;
         reducers[ACTIONS.MAP_TOGGLE_VISIBILITY_OVERLAY] = mapToggleVisibilityOverlay;
         reducers[ACTIONS.MAP_PAN] = mapPanReducer;
+        reducers[ACTIONS.LOCATION_CHANGE] = locationChangeReducer;
         reducers[ACTIONS.MAP_ZOOM] = mapZoomReducer;
         reducers[ACTIONS.MAP_FULLSCREEN] = mapFullscreenReducer;
         reducers[ACTIONS.SHOW_MAP_ACTIVE_OVERLAYS] = showActiveOverlaysReducer;
@@ -91,6 +92,21 @@
             }
             return newState;
         }
+
+        /**
+         * @param {Object} oldState
+         * @param {Array} payload - The new position in Array format, e.g. [52.123, 4.789]
+         *
+         * @returns {Object} newState
+         */
+        function locationChangeReducer (oldState, payload) {
+            var newState = angular.copy(oldState);
+
+            newState.map.viewCenter = payload;
+
+            return newState;
+        }
+
         /**
          * @param {Object} oldState
          * @param {Array} payload - The new position in Array format, e.g. [52.123, 4.789]
@@ -98,11 +114,8 @@
          * @returns {Object} newState
          */
         function mapPanReducer (oldState, payload) {
-            var newState = angular.copy(oldState);
-
-            newState.map.viewCenter = payload;
-
-            return newState;
+            // Currently map panning is equal to simply changing the location (lat,lon)
+            return locationChangeReducer(oldState, payload);
         }
 
         /**

--- a/modules/atlas/services/redux/reducers/map-reducers.factory.test.js
+++ b/modules/atlas/services/redux/reducers/map-reducers.factory.test.js
@@ -158,6 +158,19 @@ describe('The map reducers', function () {
         });
     });
 
+    describe('LOCATION_CHANGE', function () {
+        it('updates the location', function () {
+            var inputState = angular.copy(DEFAULT_STATE),
+                output;
+
+            output = mapReducers[ACTIONS.LOCATION_CHANGE](inputState, [51.1, 4.1]);
+            expect(output.map.viewCenter).toEqual([51.1, 4.1]);
+
+            output = mapReducers[ACTIONS.LOCATION_CHANGE](inputState, [51.2, 4.2]);
+            expect(output.map.viewCenter).toEqual([51.2, 4.2]);
+        });
+    });
+
     describe('MAP_ZOOM', function () {
         it('can update the zoom and viewCenter property', function () {
             var inputState = angular.copy(DEFAULT_STATE),

--- a/modules/shared/services/redux/actions.constant.js
+++ b/modules/shared/services/redux/actions.constant.js
@@ -37,6 +37,8 @@
             SHOW_PAGE: 'SHOW_PAGE',
 
             SHOW_PRINT: 'SHOW_PRINT',
-            HIDE_PRINT: 'HIDE_PRINT'
+            HIDE_PRINT: 'HIDE_PRINT',
+
+            LOCATION_CHANGE: 'LOCATION_CHANGE'
         });
 })();

--- a/modules/straatbeeld/components/straatbeeld/straatbeeld.directive.js
+++ b/modules/straatbeeld/components/straatbeeld/straatbeeld.directive.js
@@ -45,9 +45,18 @@
                         var type = scope.state.isInitial ? ACTIONS.SHOW_STRAATBEELD_INITIAL
                             : ACTIONS.SHOW_STRAATBEELD_SUBSEQUENT;
 
+                        // Dispatch an action to change the pano
                         store.dispatch({
                             type: type,
                             payload: straatbeeldData
+                        });
+
+                        // Dispatch an action to change the location
+                        // This is a separate action. An open pano should not prevent changing the location
+                        // in any other view (eg map panning should still be possible)
+                        store.dispatch({
+                            type: ACTIONS.LOCATION_CHANGE,
+                            payload: straatbeeldData.location
                         });
                     });
                 }

--- a/modules/straatbeeld/components/straatbeeld/straatbeeld.directive.test.js
+++ b/modules/straatbeeld/components/straatbeeld/straatbeeld.directive.test.js
@@ -131,12 +131,32 @@ describe('The dp-straatbeeld directive', function () {
             directive.isolateScope().state.id = 'ABC';
             directive.isolateScope().$apply();
 
-            expect($store.dispatch).toHaveBeenCalledTimes(1);
+            expect($store.dispatch).toHaveBeenCalledTimes(2);   // show pano and change location
 
             directive.isolateScope().state.id = 'XYZ';
             directive.isolateScope().$apply();
 
-            expect($store.dispatch).toHaveBeenCalledTimes(2);
+            expect($store.dispatch).toHaveBeenCalledTimes(4);
+        });
+
+        it('triggers both show and location actions', function () {
+            var directive = getDirective({}, false);
+            expect($store.dispatch).not.toHaveBeenCalled();
+
+            directive.isolateScope().state.id = 'ABC';
+            directive.isolateScope().$apply();
+
+            expect($store.dispatch).toHaveBeenCalledTimes(2);   // show pano and change location
+            expect($store.dispatch).toHaveBeenCalledWith({
+                type: ACTIONS.SHOW_STRAATBEELD_SUBSEQUENT,
+                payload: {
+                    foo: 'bar'
+                }
+            });
+            expect($store.dispatch).toHaveBeenCalledWith({
+                type: ACTIONS.LOCATION_CHANGE,
+                payload: undefined
+            });
         });
     });
 


### PR DESCRIPTION
Een hotspot click triggert een straatbeeld change en een location change
De location change resulteert in een wijziging van lat/lon wat bij een openstaande map resulteert in het aanpassen van de positie
Door gebruik te maken van twee actions blijft het nog steeds mogelijk om binnen de map te pannen
Zodra echter een hotspot wordt aangeklikt zal de map zich automatisch weer centreren op de hotspot locatie
MapPan en LocationChange zijn feitelijk gelijk maar dat hoeft niet altijd zo te blijven
In de reducer is mappan nu uitgedrukt in een locationchange