### PR TITLE
Bug/1917 print fixes

### DIFF
--- a/modules/header/components/header/_header.scss
+++ b/modules/header/components/header/_header.scss
@@ -91,7 +91,7 @@
 
 .c-exit-print-mode {
   position: absolute;
-  top: $base-whitespace * 2;
+  top: -41px;
   right: -21px;
 }
 

--- a/modules/map/components/active-overlays/_active-overlays.scss
+++ b/modules/map/components/active-overlays/_active-overlays.scss
@@ -26,6 +26,12 @@
   }
 }
 
+.is-print-mode {
+  .c-toggle-active-overlays {
+    display: none;
+  }
+}
+
 .c-toggle-active-overlays__icon {
   display: block;
   position: absolute;

--- a/modules/map/components/map/_map-print.scss
+++ b/modules/map/components/map/_map-print.scss
@@ -9,3 +9,9 @@
   margin-top: $base-whitespace * 2.1;
   border-bottom-width: 1px;
 }
+
+@media print {
+  .leaflet-control-zoom {
+    display: none;
+  }
+}

--- a/modules/map/components/toggle-layer-selection/_toggle-layer-selection.scss
+++ b/modules/map/components/toggle-layer-selection/_toggle-layer-selection.scss
@@ -17,6 +17,12 @@
   }
 }
 
+.is-print-mode {
+  .c-toggle-layer-selection {
+    display: none;
+  }
+}
+
 .c-toggle-layer-selection__icon {
   display: block;
   position: absolute;

--- a/modules/map/services/measure/_measure.scss
+++ b/modules/map/services/measure/_measure.scss
@@ -12,3 +12,9 @@
 .leaflet-measure-resultpopup {
   @include font-size($body-font);
 }
+
+.is-print-mode {
+  .leaflet-control-measure {
+    display: none;
+  }
+}


### PR DESCRIPTION
Kaart in printversie toont alleen zoom controls en schaal (En legenda als die al open stond)
de te-printen kaart (apple-p, print preview) toont niks, alleen schaal

