### PR TITLE
Added trim_trailing_whitespace in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,7 @@
 [*]
 indent_style = space
 indent_size = 4
+trim_trailing_whitespace = true
 insert_final_newline = true
 
 [{*.scss,*.json}]


### PR DESCRIPTION
Enabled trim_trailing_whitespace in editorconfig. Webstorm adds whitespace on 'empty lines' when pressing ENTER. It's now in sync with the eslint config.