### PR TITLE
Feature/bugfix server error

### DIFF
--- a/modules/atlas/services/redux/reducers/search-reducers.factory.js
+++ b/modules/atlas/services/redux/reducers/search-reducers.factory.js
@@ -88,9 +88,11 @@
         function fetchSearchResultsCategoryReducer (oldState, payload) {
             var newState = angular.copy(oldState);
 
-            newState.search.isLoading = true;
-            newState.search.category = payload;
-            newState.search.numberOfResults = null;
+            if (angular.isObject(newState.search)) {
+                newState.search.isLoading = true;
+                newState.search.category = payload;
+                newState.search.numberOfResults = null;
+            }
 
             return newState;
         }
@@ -104,8 +106,10 @@
         function showSearchResultsReducer (oldState, payload) {
             var newState = angular.copy(oldState);
 
-            newState.search.isLoading = false;
-            newState.search.numberOfResults = payload;
+            if (angular.isObject(newState.search)) {
+                newState.search.isLoading = false;
+                newState.search.numberOfResults = payload;
+            }
 
             return newState;
         }

--- a/modules/atlas/services/redux/reducers/search-reducers.factory.test.js
+++ b/modules/atlas/services/redux/reducers/search-reducers.factory.test.js
@@ -249,6 +249,15 @@ describe('The search-reducers factory', function () {
         });
     });
 
+    describe('FETCH_SEARCH_RESULTS_CATEGORY', function () {
+        it('only updates the search state when a search is active', function () {
+            let inputState = angular.copy(DEFAULT_STATE);
+            delete inputState.search;
+            searchReducers[ACTIONS.FETCH_SEARCH_RESULTS_CATEGORY.id](inputState, 'adres');
+            expect(inputState.search).toBeUndefined();
+        });
+    });
+
     describe('SHOW_SEARCH_RESULTS', function () {
         var inputState,
             output;
@@ -272,6 +281,15 @@ describe('The search-reducers factory', function () {
 
         it('sets isLoading to false', function () {
             expect(output.search.isLoading).toBe(false);
+        });
+    });
+
+    describe('SHOW_SEARCH_RESULTS', function () {
+        it('only updates the search state when a search is active', function () {
+            let inputState = angular.copy(DEFAULT_STATE);
+            delete inputState.search;
+            searchReducers[ACTIONS.SHOW_SEARCH_RESULTS.id](inputState, 23);
+            expect(inputState.search).toBeUndefined();
         });
     });
 });

--- a/modules/shared/services/api/api.factory.js
+++ b/modules/shared/services/api/api.factory.js
@@ -5,12 +5,12 @@
         .module('dpShared')
         .factory('api', apiFactory);
 
-    apiFactory.$inject = ['$http', 'user', 'environment'];
+    apiFactory.$inject = ['$http', 'httpStatus', 'user', 'environment'];
 
-    function apiFactory ($http, user, environment) {
+    function apiFactory ($http, httpStatus, user, environment) {
         return {
-            getByUrl: getByUrl,
-            getByUri: getByUri
+            getByUrl,
+            getByUri
         };
 
         /**
@@ -43,6 +43,7 @@
 
             if (angular.isObject(cancel) && cancel.promise) {
                 options.timeout = cancel.promise;
+                options.timeout.finally(() => httpStatus.registerCancel(options));
             }
 
             return $http(options).then(response => response.data);

--- a/modules/shared/services/http-interceptor/http-interceptor.factory.js
+++ b/modules/shared/services/http-interceptor/http-interceptor.factory.js
@@ -15,8 +15,21 @@
 
         function responseError (response) {
             // register server errors (5xx) and client errors (4xx)
-            let isServerError = response.status <= 0 || (500 <= response.status && response.status <= 599),
+            let isServerError = 500 <= response.status && response.status <= 599,
                 isClientError = 400 <= response.status && response.status <= 499;
+
+            // register other server errors
+            if (response.status <= 0) {
+                // Check if the error is due to a cancelled http request
+                let status = httpStatus.getStatus();
+                if (status.cancelled && status.cancelled.url === response.config.url) {
+                    // Ignore this error, it is due to a deliberate cancel of this http request
+                    status.cancelled = null;
+                } else {
+                    // This is a server error (eg CORS blocked)
+                    isServerError = true;
+                }
+            }
 
             if (isServerError) {
                 httpStatus.registerError(httpStatus.SERVER_ERROR);

--- a/modules/shared/services/http-interceptor/http-interceptor.factory.js
+++ b/modules/shared/services/http-interceptor/http-interceptor.factory.js
@@ -15,7 +15,7 @@
 
         function responseError (response) {
             // register server errors (5xx) and client errors (4xx)
-            let isServerError = 500 <= response.status && response.status <= 599,
+            let isServerError = response.status <= 0 || (500 <= response.status && response.status <= 599),
                 isClientError = 400 <= response.status && response.status <= 499;
 
             if (isServerError) {

--- a/modules/shared/services/http-interceptor/http-status.factory.js
+++ b/modules/shared/services/http-interceptor/http-status.factory.js
@@ -10,7 +10,8 @@
         const errorTypes = ['SERVER_ERROR', 'NOT_FOUND_ERROR'],
             exportObject = exportErrorTypes({
                 getStatus,
-                registerError
+                registerError,
+                registerCancel
             });
 
         let currentStatus = {
@@ -35,6 +36,10 @@
 
             currentStatus[key] = true;
             currentStatus.hasErrors = true;
+        }
+
+        function registerCancel (request) {
+            currentStatus.cancelled = request;
         }
 
         function resetTypeFlags () {


### PR DESCRIPTION
Sommige http foutmeldingen hebben status -1
Deze fouten zijn serverfouten (bv CORS) die nu niet worden getoond
De code is aangepast om ook deze fouten te tonen
Er is een voorziening getroffen om status -1 tgv cancellation of http requests te skippen
Er is een extra beveiliging in de search reducer aangebracht tegen null states. Dit kan voorkomen na een server fout.