### PR TITLE
Jenkins sets version id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ node_modules
 reports
 *.iml
 modules/shared/styles/config/mixins/_icons.scss
-modules/atlas/atlas.version.js

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules
 reports
 *.iml
 modules/shared/styles/config/mixins/_icons.scss
+modules/atlas/atlas.version.js

--- a/grunt/string-replace.js
+++ b/grunt/string-replace.js
@@ -1,5 +1,4 @@
 module.exports = function (grunt) {
-
     var targets = {
         dist: {
             files: [{
@@ -13,8 +12,7 @@ module.exports = function (grunt) {
                 }]
             }
         }
-    }
-
+    };
 
     return targets;
 };

--- a/grunt/string-replace.js
+++ b/grunt/string-replace.js
@@ -7,8 +7,8 @@ module.exports = function (grunt) {
             }],
             options: {
                 replacements: [{
-                    pattern: '__VERSIONID__',
-                    replacement: grunt.option('versionid')
+                    pattern: '__BUILDID__',
+                    replacement: grunt.option('buildid')
                 }]
             }
         }

--- a/grunt/string-replace.js
+++ b/grunt/string-replace.js
@@ -1,0 +1,20 @@
+module.exports = function (grunt) {
+
+    var targets = {
+        dist: {
+            files: [{
+                src: 'modules/atlas/atlas.version.js.template',
+                dest: 'modules/atlas/atlas.version.js'
+            }],
+            options: {
+                replacements: [{
+                    pattern: '__VERSIONID__',
+                    replacement: grunt.option('versionid')
+                }]
+            }
+        }
+    }
+
+
+    return targets;
+};

--- a/grunt/tasks/build-tasks.js
+++ b/grunt/tasks/build-tasks.js
@@ -18,4 +18,12 @@ module.exports = function (grunt) {
         'karma-modules-fullcoverage',
         'clean:temp'
     ]);
+
+    grunt.registerTask('set-version-id', function () {
+        if (grunt.option('versionid')) {
+            grunt.task.run(['string-replace']);
+        } else {
+            grunt.log.error('Usage: grunt set-version-id --versionid=<versionid>');
+        }
+    })
 };

--- a/grunt/tasks/build-tasks.js
+++ b/grunt/tasks/build-tasks.js
@@ -25,5 +25,5 @@ module.exports = function (grunt) {
         } else {
             grunt.log.error('Usage: grunt set-version-id --versionid=<versionid>');
         }
-    })
+    });
 };

--- a/grunt/tasks/build-tasks.js
+++ b/grunt/tasks/build-tasks.js
@@ -19,11 +19,11 @@ module.exports = function (grunt) {
         'clean:temp'
     ]);
 
-    grunt.registerTask('set-version-id', function () {
-        if (grunt.option('versionid')) {
+    grunt.registerTask('set-build-id', function () {
+        if (grunt.option('buildid')) {
             grunt.task.run(['string-replace']);
         } else {
-            grunt.log.error('Usage: grunt set-version-id --versionid=<versionid>');
+            grunt.log.error('Usage: grunt set-build-id --buildid=<buildid>');
         }
     });
 };

--- a/grunt/tasks/config.js
+++ b/grunt/tasks/config.js
@@ -31,6 +31,7 @@ module.exports = function (grunt) {
         postcss: require(gruntDir + 'postcss')(grunt),
         sass: require(gruntDir + 'sass'),
         sasslint: require(gruntDir + 'sasslint'),
+        'string-replace': require(gruntDir + 'string-replace')(grunt),
         svg_sprite: require(gruntDir + 'svg-sprite'),
         tags: require(gruntDir + 'script-link-tags')(grunt),
         watch: require(gruntDir + 'watch')
@@ -54,4 +55,5 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks('grunt-sass');
     grunt.loadNpmTasks('grunt-sass-lint');
     grunt.loadNpmTasks('grunt-script-link-tags');
+    grunt.loadNpmTasks('grunt-string-replace');
 };

--- a/modules/atlas/atlas.version.js
+++ b/modules/atlas/atlas.version.js
@@ -2,7 +2,7 @@
     'use strict';
 
     /*
-     * Do not change this module
+     * ATTENTION: Do not change this module, the contents will be overwritten during the build process
      */
 
     angular

--- a/modules/atlas/atlas.version.js
+++ b/modules/atlas/atlas.version.js
@@ -7,5 +7,7 @@
 
     angular
         .module('atlas')
-        .constant('ATLAS_BUILD', 'Development');
+        .constant('ATLAS_VERSION', {
+            build: 'Development'
+        });
 })();

--- a/modules/atlas/atlas.version.js
+++ b/modules/atlas/atlas.version.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    /*
+     * Do not change this module
+     */
+
+    angular
+        .module('atlas')
+        .constant('ATLAS_VERSION', 'Development');
+})();

--- a/modules/atlas/atlas.version.js
+++ b/modules/atlas/atlas.version.js
@@ -7,5 +7,5 @@
 
     angular
         .module('atlas')
-        .constant('ATLAS_VERSION', 'Development');
+        .constant('ATLAS_BUILD', 'Development');
 })();

--- a/modules/atlas/atlas.version.js.template
+++ b/modules/atlas/atlas.version.js.template
@@ -1,6 +1,10 @@
 (function () {
     'use strict';
 
+    /*
+     * ATTENTION: Do not change this module, the contents will be overwritten during the build process
+     */
+
     angular
         .module('atlas')
         .constant('ATLAS_VERSION', '__VERSIONID__');

--- a/modules/atlas/atlas.version.js.template
+++ b/modules/atlas/atlas.version.js.template
@@ -7,5 +7,5 @@
 
     angular
         .module('atlas')
-        .constant('ATLAS_VERSION', '__VERSIONID__');
+        .constant('ATLAS_BUILD', '__BUILDID__');
 })();

--- a/modules/atlas/atlas.version.js.template
+++ b/modules/atlas/atlas.version.js.template
@@ -1,0 +1,7 @@
+(function () {
+    'use strict';
+
+    angular
+        .module('atlas')
+        .constant('ATLAS_VERSION', '__VERSIONID__');
+})();

--- a/modules/atlas/atlas.version.js.template
+++ b/modules/atlas/atlas.version.js.template
@@ -7,5 +7,7 @@
 
     angular
         .module('atlas')
-        .constant('ATLAS_BUILD', '__BUILDID__');
+        .constant('ATLAS_VERSION', {
+            build: '__BUILDID__'
+        });
 })();

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "grunt-sass": "^1.2.1",
     "grunt-sass-lint": "^0.2.0",
     "grunt-script-link-tags": "^1.0.2",
+    "grunt-string-replace": "^1.3.1",
     "grunt-svg-sprite": "^1.3.6",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.22",


### PR DESCRIPTION
De bedoeling is dat als deze versie live is, in het Jenkins script het volgende commando wordt toegevoegd:

grunt set-version-id --versionid=${BUILD_TAG}.${GIT_COMMIT}

Het is een technisch veld dat kan worden gebruikt om na te gaan in welke job en op basis van welke commit de applicatie is gebuild.

Werking: Er wordt een constante aangemaakt ATLAS_VERSION die nu nog niet wordt gebruikt in de applicatie maar die bijvoorbeeld als een hover of via een menu item kan worden getoond. Ook kan de id worden meegestuurd in 'terugmelden' of als we in de toekomst frontend error messages gaan terugmelden aan het backend.
