### PR TITLE
[tg-2333] align right formatter

### DIFF
--- a/modules/data-selection/components/formatter/align-right/align-right.filter.js
+++ b/modules/data-selection/components/formatter/align-right/align-right.filter.js
@@ -5,16 +5,9 @@
         .module('dpDataSelection')
         .filter('alignRight', alignRightFilter);
 
-    alignRightFilter.$inject = ['$document'];
-
-    function alignRightFilter ($document) {
+    function alignRightFilter () {
         return function (input) {
-            let div = $document[0].createElement('div');
-
-            div.setAttribute('class', 'u-align--right');
-            div.innerText = input;
-
-            return "<div class='u-align--right'>" + input + "</div>";//div.outerHTML;
+            return '<div class=\'u-align--right\'>' + input + '</div>';
         };
     }
 })();

--- a/modules/data-selection/components/formatter/align-right/align-right.filter.js
+++ b/modules/data-selection/components/formatter/align-right/align-right.filter.js
@@ -14,7 +14,7 @@
             div.setAttribute('class', 'u-align--right');
             div.innerText = input;
 
-            return div.outerHTML;
+            return "<div class='u-align--right'>" + input + "</div>";//div.outerHTML;
         };
     }
 })();

--- a/modules/data-selection/components/formatter/align-right/align-right.filter.test.js
+++ b/modules/data-selection/components/formatter/align-right/align-right.filter.test.js
@@ -16,4 +16,12 @@ describe('The alignRight filter', function () {
         expect(output.attr('class')).toBe('u-align--right');
         expect(output.text()).toBe('some text');
     });
+
+    it('uses single quotes around attribute values', function () {
+        // Bugfix tg-2333; Firefox 38 (used on ADW) can't use ng-bind-html in combination with double quotes
+        const output = alignRightFilter('some text');
+
+        expect(output).toContain('\'');
+        expect(output).not.toContain('"');
+    });
 });

--- a/modules/data-selection/components/formatter/formatter.component.js
+++ b/modules/data-selection/components/formatter/formatter.component.js
@@ -37,6 +37,6 @@
             }).join(' ');
         }
 
-        console.log(formattedValue);
+        console.log(vm.formattedValue);
     }
 })();

--- a/modules/data-selection/components/formatter/formatter.component.js
+++ b/modules/data-selection/components/formatter/formatter.component.js
@@ -36,7 +36,5 @@
                 return variable.value;
             }).join(' ');
         }
-
-        console.log(vm.formattedValue);
     }
 })();

--- a/modules/data-selection/components/formatter/formatter.component.js
+++ b/modules/data-selection/components/formatter/formatter.component.js
@@ -36,5 +36,7 @@
                 return variable.value;
             }).join(' ');
         }
+
+        console.log(formattedValue);
     }
 })();

--- a/modules/data-selection/data-selection-config.factory.js
+++ b/modules/data-selection/data-selection-config.factory.js
@@ -63,15 +63,18 @@
                         },
                         {
                             label: 'Num.',
-                            variables: ['huisnummer']
+                            variables: ['huisnummer'],
+                            formatter: 'alignRight'
                         },
                         {
                             label: 'Let.',
-                            variables: ['huisletter']
+                            variables: ['huisletter'],
+                            formatter: 'alignRight'
                         },
                         {
                             label: 'Toev.',
-                            variables: ['huisnummer_toevoeging']
+                            variables: ['huisnummer_toevoeging'],
+                            formatter: 'alignRight'
                         },
                         {
                             label: 'Postcode',


### PR DESCRIPTION
Firefox 38 kan niet omgaan met dubbele quotes i.c.m. ng-bind-html.