### PR TITLE
Bugfix/tg 2353 puntenwolk traagheid

### DIFF
--- a/modules/data-selection/components/data-selection/data-selection.component.js
+++ b/modules/data-selection/components/data-selection/data-selection.component.js
@@ -6,7 +6,7 @@
         .component('dpDataSelection', {
             templateUrl: 'modules/data-selection/components/data-selection/data-selection.html',
             bindings: {
-                state: '='
+                state: '<'
             },
             controller: DpDataSelectionController,
             controllerAs: 'vm'
@@ -18,7 +18,15 @@
         let vm = this;
         const MAXIMUM_NUMBER_OF_MARKERS = 10000;
 
-        $scope.$watch('vm.state', fetchData, true);
+        $scope.$watch(function () {
+            // Watching all state variables except markers and isLoading
+            return [
+                vm.state.dataset,
+                vm.state.view,
+                vm.state.filters,
+                vm.state.page
+            ];
+        }, fetchData, true);
 
         function fetchData () {
             vm.isLoading = true;

--- a/modules/map/services/highlight/clustered-markers-config.constant.js
+++ b/modules/map/services/highlight/clustered-markers-config.constant.js
@@ -5,8 +5,6 @@
         .module('dpMap')
         .constant('CLUSTERED_MARKERS_CONFIG', {
             chunkedLoading: true,
-            disableClusteringAtZoom: 14,
-            maxClusterRadius: 50,
-            showCoverageOnHover: false
+            maxClusterRadius: 50
         });
 })();

--- a/modules/shared/services/environment/environment.factory.js
+++ b/modules/shared/services/environment/environment.factory.js
@@ -16,7 +16,7 @@
                 break;
 
             default:
-                environment = 'DEVELOPMENT';
+                environment = 'PRODUCTION';
         }
 
         ENVIRONMENT_CONFIG[environment].NAME = environment;

--- a/modules/shared/services/environment/environment.factory.js
+++ b/modules/shared/services/environment/environment.factory.js
@@ -16,7 +16,7 @@
                 break;
 
             default:
-                environment = 'PRODUCTION';
+                environment = 'DEVELOPMENT';
         }
 
         ENVIRONMENT_CONFIG[environment].NAME = environment;


### PR DESCRIPTION
Ik heb drie dingen aangepast om de snelheid te verbeteren:

- configuratie van de Leaflet clustered markers plugin
- API calls werden per ongeluk twee keer uitgevoerd

De derde verbetering heeft zijn eigen PR, namelijk een dp-link wijziging. Zonder deze derde wijziging blijft het traag. Functioneel testen heeft pas zin als beide PRs zijn doorgevoerd.