### PR TITLE
Active overlays aan/uit - dp-link gerelateerd probleem

### DIFF
--- a/modules/shared/services/redux/actions.constant.js
+++ b/modules/shared/services/redux/actions.constant.js
@@ -67,11 +67,14 @@
             },
             SHOW_MAP_ACTIVE_OVERLAYS: {
                 id: 'SHOW_MAP_ACTIVE_OVERLAYS',
-                replace: true
+                replace: true,
+                isButton: true
+
             },
             HIDE_MAP_ACTIVE_OVERLAYS: {
                 id: 'HIDE_MAP_ACTIVE_OVERLAYS',
-                replace: true
+                replace: true,
+                isButton: true
             },
 
             FETCH_DETAIL: {


### PR DESCRIPTION
Aan en uitzetten van de active overlays moet een button zijn in plaats van een link