### PR TITLE
Bugfix/kaartlagen bij list view

### DIFF
--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -23,7 +23,7 @@
                 visibility.dataSelectionList = state.dataSelection.view === 'LIST';
 
                 visibility.map = visibility.dataSelectionList;
-                visibility.layerSelection = false;
+                visibility.layerSelection = state.layerSelection;
                 visibility.detail = false;
                 visibility.page = false;
                 visibility.searchResults = false;

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -23,7 +23,7 @@
                 visibility.dataSelectionList = state.dataSelection.view === 'LIST';
 
                 visibility.map = visibility.dataSelectionList;
-                visibility.layerSelection = state.layerSelection;
+                visibility.layerSelection = visibility.dataSelectionList && state.layerSelection;
                 visibility.detail = false;
                 visibility.page = false;
                 visibility.searchResults = false;


### PR DESCRIPTION
Ja, ook een voorbeeld van doorborduren op een bestaande eigenaardigheid.

De eigenaardigheid is dat dataSelectionList in de visibility wordt opgenomen. Dat heeft als reden dat deze waarde later nodig is in determineColumnSizesDefault. Aangezien deze methode geen toegang heeft tot de state en determineVisibility wel wordt de shortcut gebruikt om het in de visibility op te nemen.

dataSelection TABLE is fullscreen en dataSelection LIST is 2/3 met daarnaast de kaart. Tja...