### PR TITLE
fullscreen straatbeeld print bugfix

### DIFF
--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -59,7 +59,10 @@
 
                     <div ng-controller="StraatbeeldController as straatbeeld"
                          class="u-dashboard--full-height">
-                        <dp-straatbeeld state="straatbeeld.straatbeeldState" is-print-mode="vm.isPrintMode"></dp-straatbeeld>
+                        <dp-straatbeeld
+                            state="straatbeeld.straatbeeldState"
+                            resize="[vm.isPrintMode, vm.visibility.httpStatus.hasErrors]">
+                        </dp-straatbeeld>
                     </div>
                 </div>
 
@@ -100,8 +103,10 @@
                        class="u-dashboard--full-height">
 
                         <!--Resize straatbeeld when any of printMode or errorMode changes-->
-                        <dp-straatbeeld state="straatbeeld.straatbeeldState"
-                                        resize="[vm.isPrintMode, vm.visibility.httpStatus.hasErrors]"></dp-straatbeeld>
+                        <dp-straatbeeld
+                            state="straatbeeld.straatbeeldState"
+                            resize="[vm.isPrintMode, vm.visibility.httpStatus.hasErrors]">
+                        </dp-straatbeeld>
                     </div>
 
                     <!-- Data selection -->


### PR DESCRIPTION
In fullscreen straatbeeld modus verloor je de kijkrichting en FOV bij het schakelen tussen de non-print en print versie.