### PR TITLE
[tg-2424] state active vs visible

### DIFF
--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -8,6 +8,11 @@
     dashboardColumnsFactory.$inject = ['httpStatus'];
 
     function dashboardColumnsFactory (httpStatus) {
+        /*
+        - activity means the components is loaded (ng-if)
+        - visibility means the components if shown, inactive components are never shown (ng-show)
+        - columnSizes also determine whether or not something is fullscreen (.u-col-sm--12)
+         */
         return {
             determineActivity,
             determineVisibility,

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -83,13 +83,14 @@
             return visibility;
         }
 
-        function determineColumnSizes (state, visibility, isPrintMode) {
+        function determineColumnSizes (state) {
+            const visibility = determineVisibility(state);
             const hasFullscreenElement = visibility.map && state.map.isFullscreen ||
                 (visibility.straatbeeld && state.straatbeeld.isFullscreen) ||
                 (visibility.detail && state.detail.isFullscreen) ||
                 (visibility.dataSelection && state.dataSelection.isFullscreen);
 
-            if (!isPrintMode) {
+            if (!state.isPrintMode) {
                 return determineColumnSizesDefault (state, visibility, hasFullscreenElement);
             } else {
                 return determineColumnSizesPrint (state, visibility, hasFullscreenElement);

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -95,8 +95,8 @@
                 columnSizes.right = 0;
             } else if (hasFullscreenElement) {
                 columnSizes.left = 0;
-                columnSizes.middle = 12;
-                columnSizes.right = 0;
+                columnSizes.middle = state.map.isFullscreen ? 12 : 0;
+                columnSizes.right = !state.map.isFullscreen ? 12 : 0;
             } else if ((visibility.detail && state.detail.isFullscreen) ||
                 (visibility.dataSelection && state.dataSelection.isFullscreen)) {
                 columnSizes.left = 0;

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -9,8 +9,8 @@
 
     function dashboardColumnsFactory (httpStatus) {
         /*
-        - activity means the components is loaded (ng-if)
-        - visibility means the components if shown, inactive components are never shown (ng-show)
+        - activity means the component is loaded (ng-if)
+        - visibility means the components is shown, inactive components are never shown (ng-show)
         - columnSizes also determine whether or not something is fullscreen (.u-col-sm--12)
          */
         return {
@@ -86,7 +86,8 @@
         function determineColumnSizes (state, visibility, isPrintMode) {
             const hasFullscreenElement = visibility.map && state.map.isFullscreen ||
                 (visibility.straatbeeld && state.straatbeeld.isFullscreen) ||
-                (visibility.detail && state.detail.isFullscreen);
+                (visibility.detail && state.detail.isFullscreen) ||
+                (visibility.dataSelection && state.dataSelection.isFullscreen);
 
             if (!isPrintMode) {
                 return determineColumnSizesDefault (state, visibility, hasFullscreenElement);
@@ -106,11 +107,6 @@
                 columnSizes.left = 0;
                 columnSizes.middle = state.map.isFullscreen ? 12 : 0;
                 columnSizes.right = !state.map.isFullscreen ? 12 : 0;
-            } else if ((visibility.detail && state.detail.isFullscreen) ||
-                (visibility.dataSelection && state.dataSelection.isFullscreen)) {
-                columnSizes.left = 0;
-                columnSizes.middle = 0;
-                columnSizes.right = 12;
             } else {
                 columnSizes.left = 0;
                 columnSizes.middle = 4;
@@ -129,18 +125,11 @@
                 columnSizes.right = 0;
             } else if (hasFullscreenElement) {
                 columnSizes.left = 0;
-                columnSizes.middle = 12;
-                columnSizes.right = 0;
-            } else if ((visibility.detail && state.detail.isFullscreen) ||
-                visibility.page ||
-                visibility.searchResults ||
-                visibility.dataSelection && state.dataSelection.isFullscreen) {
-                columnSizes.left = 0;
-                columnSizes.middle = 0;
-                columnSizes.right = 12;
+                columnSizes.middle = state.map.isFullscreen ? 12 : 0;
+                columnSizes.right = !state.map.isFullscreen ? 12 : 0;
             } else {
                 columnSizes.left = 0;
-                columnSizes.middle = 12;
+                columnSizes.middle = visibility.page || visibility.searchResults ? 0 : 12;
                 columnSizes.right = 12;
             }
 

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -30,7 +30,7 @@
             const activity = determineActivity(state);
             let visibility = {};
 
-            visibility.httpStatus = httpStatus.getStatus();
+            visibility.httpStatus = httpStatus.getStatus().hasErrors;
 
             if (angular.isObject(state.dataSelection)) {
                 visibility.dataSelection = true;

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -79,48 +79,60 @@
         }
 
         function determineColumnSizes (state, visibility, hasFullscreenElement, isPrintMode) {
-            var columnSizes = {};
-
             if (!isPrintMode) {
-                if (visibility.layerSelection) {
-                    columnSizes.left = 4;
-                    columnSizes.middle = 8;
-                } else if (hasFullscreenElement) {
-                    columnSizes.left = 0;
-                    columnSizes.middle = 12;
-                } else if ((visibility.detail && state.detail.isFullscreen) ||
-                    (visibility.dataSelection && state.dataSelection.isFullscreen)) {
-                    columnSizes.left = 0;
-                    columnSizes.middle = 0;
-                } else {
-                    columnSizes.left = 0;
-                    columnSizes.middle = 4;
-                }
-
-                columnSizes.right = 12 - columnSizes.left - columnSizes.middle;
-
-                return columnSizes;
+                return determineColumnSizesDefault (state, visibility, hasFullscreenElement);
             } else {
-                if (visibility.layerSelection) {
-                    columnSizes.left = 12;
-                    columnSizes.middle = 0;
-                    columnSizes.right = 0;
-                } else if (hasFullscreenElement) {
-                    columnSizes.left = 0;
-                    columnSizes.middle = 12;
-                    columnSizes.right = 0;
-                } else if ((visibility.detail && state.detail.isFullscreen) ||
-                    visibility.page ||
-                    visibility.searchResults ||
-                    visibility.dataSelection && state.dataSelection.isFullscreen) {
-                    columnSizes.left = 0;
-                    columnSizes.middle = 0;
-                    columnSizes.right = 12;
-                } else {
-                    columnSizes.left = 0;
-                    columnSizes.middle = 12;
-                    columnSizes.right = 12;
-                }
+                return determineColumnSizesPrint (state, visibility, hasFullscreenElement);
+            }
+        }
+
+        function determineColumnSizesDefault (state, visibility, hasFullscreenElement) {
+            let columnSizes = {};
+
+            if (visibility.layerSelection) {
+                columnSizes.left = 4;
+                columnSizes.middle = 8;
+                columnSizes.right = 0;
+            } else if (hasFullscreenElement) {
+                columnSizes.left = 0;
+                columnSizes.middle = 12;
+                columnSizes.right = 0;
+            } else if ((visibility.detail && state.detail.isFullscreen) ||
+                (visibility.dataSelection && state.dataSelection.isFullscreen)) {
+                columnSizes.left = 0;
+                columnSizes.middle = 0;
+                columnSizes.right = 12;
+            } else {
+                columnSizes.left = 0;
+                columnSizes.middle = 4;
+                columnSizes.right = 8;
+            }
+
+            return columnSizes;
+        }
+
+        function determineColumnSizesPrint (state, visibility, hasFullscreenElement) {
+            let columnSizes = {};
+
+            if (visibility.layerSelection) {
+                columnSizes.left = 12;
+                columnSizes.middle = 0;
+                columnSizes.right = 0;
+            } else if (hasFullscreenElement) {
+                columnSizes.left = 0;
+                columnSizes.middle = 12;
+                columnSizes.right = 0;
+            } else if ((visibility.detail && state.detail.isFullscreen) ||
+                visibility.page ||
+                visibility.searchResults ||
+                visibility.dataSelection && state.dataSelection.isFullscreen) {
+                columnSizes.left = 0;
+                columnSizes.middle = 0;
+                columnSizes.right = 12;
+            } else {
+                columnSizes.left = 0;
+                columnSizes.middle = 12;
+                columnSizes.right = 12;
             }
 
             return columnSizes;

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -10,7 +10,7 @@
     function dashboardColumnsFactory (httpStatus) {
         /*
         - activity means the component is loaded (ng-if)
-        - visibility means the components is shown, inactive components are never shown (ng-show)
+        - visibility means the component is shown, inactive components are never shown (ng-show)
         - columnSizes also determine whether or not something is fullscreen (.u-col-sm--12)
          */
         return {
@@ -85,7 +85,7 @@
 
         function determineColumnSizes (state) {
             const visibility = determineVisibility(state);
-            const hasFullscreenElement = visibility.map && state.map.isFullscreen ||
+            const hasFullscreenElement = (visibility.map && state.map.isFullscreen) ||
                 (visibility.straatbeeld && state.straatbeeld.isFullscreen) ||
                 (visibility.detail && state.detail.isFullscreen) ||
                 (visibility.dataSelection && state.dataSelection.isFullscreen);

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -78,7 +78,11 @@
             return visibility;
         }
 
-        function determineColumnSizes (state, visibility, hasFullscreenElement, isPrintMode) {
+        function determineColumnSizes (state, visibility, isPrintMode) {
+            const hasFullscreenElement = visibility.map && state.map.isFullscreen ||
+                (visibility.straatbeeld && state.straatbeeld.isFullscreen) ||
+                (visibility.detail && state.detail.isFullscreen);
+
             if (!isPrintMode) {
                 return determineColumnSizesDefault (state, visibility, hasFullscreenElement);
             } else {

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -9,11 +9,25 @@
 
     function dashboardColumnsFactory (httpStatus) {
         return {
-            determineVisibility: determineVisibility,
-            determineColumnSizes: determineColumnSizes
+            determineActivity,
+            determineVisibility,
+            determineColumnSizes
         };
 
+        function determineActivity (state) {
+            return {
+                map: true,
+                layerSelection: state.layerSelection,
+                searchResults: angular.isObject(state.search),
+                page: angular.isString(state.page),
+                detail: angular.isObject(state.detail),
+                straatbeeld: angular.isObject(state.straatbeeld),
+                dataSelection: angular.isObject(state.dataSelection)
+            };
+        }
+
         function determineVisibility (state) {
+            const activity = determineActivity(state);
             let visibility = {};
 
             visibility.httpStatus = httpStatus.getStatus();
@@ -29,13 +43,18 @@
                 visibility.straatbeeld = false;
             } else {
                 if (state.isPrintMode) {
-                    visibility.map = isMapVisible(state);
+                    visibility.map = !activity.layerSelection &&
+                        (
+                            state.map.isFullscreen ||
+                            (activity.detail && !state.detail.isInvisible && angular.isObject(state.detail.geometry)) ||
+                            activity.straatbeeld && !state.straatbeeld.isInvisible
+                        );
                 } else {
                     visibility.map = true;
                 }
 
                 visibility.layerSelection = state.layerSelection;
-                visibility.straatbeeld = isStraatbeeldVisible(state);
+                visibility.straatbeeld = activity.straatbeeld && !state.straatbeeld.isInvisible;
 
                 if (visibility.straatbeeld && state.straatbeeld.isFullscreen) {
                     visibility.detail = false;
@@ -48,9 +67,9 @@
                     visibility.searchResults = false;
                     visibility.straatbeeld = false;
                 } else {
-                    visibility.detail = isDetailVisible(state);
+                    visibility.detail = activity.detail && !state.detail.isInvisible;
                     visibility.page = angular.isString(state.page);
-                    visibility.searchResults = isSearchResultsVisible(state);
+                    visibility.searchResults = activity.searchResults;
                 }
 
                 visibility.dataSelection = false;
@@ -59,83 +78,52 @@
             return visibility;
         }
 
-        function isStraatbeeldVisible (state) {
-            return angular.isObject(state.straatbeeld) && !(state.straatbeeld.isInvisible);
-        }
-
-        function isMapVisible (state) {
-            return !state.layerSelection &&
-                (state.map.isFullscreen ||
-                 (isDetailVisible(state) && angular.isObject(state.detail.geometry)) ||
-                 isStraatbeeldVisible(state)
-                );
-        }
-
-        function isDetailVisible (state) {
-            return angular.isObject(state.detail) && !(state.detail.isInvisible);
-        }
-
-        function isSearchResultsVisible (state) {
-            return angular.isObject(state.search) &&
-                (angular.isString(state.search.query) || angular.isArray(state.search.location));
-        }
-
-        function determineColumnSizesDefault (state, visibility, hasFullscreenElement) {
-            var columnSizes = {};
-
-            if (visibility.layerSelection) {
-                columnSizes.left = 4;
-                columnSizes.middle = 8;
-            } else if (hasFullscreenElement) {
-                columnSizes.left = 0;
-                columnSizes.middle = 12;
-            } else if ((visibility.detail && state.detail.isFullscreen) ||
-                (visibility.dataSelection && state.dataSelection.isFullscreen)) {
-                columnSizes.left = 0;
-                columnSizes.middle = 0;
-            } else {
-                columnSizes.left = 0;
-                columnSizes.middle = 4;
-            }
-
-            columnSizes.right = 12 - columnSizes.left - columnSizes.middle;
-
-            return columnSizes;
-        }
-
-        function determineColumnSizesPrint (state, visibility, hasFullscreenElement) {
-            var columnSizes = {};
-
-            if (visibility.layerSelection) {
-                columnSizes.left = 12;
-                columnSizes.middle = 0;
-                columnSizes.right = 0;
-            } else if (hasFullscreenElement) {
-                columnSizes.left = 0;
-                columnSizes.middle = 12;
-                columnSizes.right = 0;
-            } else if ((visibility.detail && state.detail.isFullscreen) ||
-                visibility.page ||
-                visibility.searchResults ||
-                visibility.dataSelection && state.dataSelection.isFullscreen) {
-                columnSizes.left = 0;
-                columnSizes.middle = 0;
-                columnSizes.right = 12;
-            } else {
-                columnSizes.left = 0;
-                columnSizes.middle = 12;
-                columnSizes.right = 12;
-            }
-
-            return columnSizes;
-        }
-
         function determineColumnSizes (state, visibility, hasFullscreenElement, isPrintMode) {
+            var columnSizes = {};
+
             if (!isPrintMode) {
-                return determineColumnSizesDefault(state, visibility, hasFullscreenElement);
+                if (visibility.layerSelection) {
+                    columnSizes.left = 4;
+                    columnSizes.middle = 8;
+                } else if (hasFullscreenElement) {
+                    columnSizes.left = 0;
+                    columnSizes.middle = 12;
+                } else if ((visibility.detail && state.detail.isFullscreen) ||
+                    (visibility.dataSelection && state.dataSelection.isFullscreen)) {
+                    columnSizes.left = 0;
+                    columnSizes.middle = 0;
+                } else {
+                    columnSizes.left = 0;
+                    columnSizes.middle = 4;
+                }
+
+                columnSizes.right = 12 - columnSizes.left - columnSizes.middle;
+
+                return columnSizes;
             } else {
-                return determineColumnSizesPrint(state, visibility, hasFullscreenElement);
+                if (visibility.layerSelection) {
+                    columnSizes.left = 12;
+                    columnSizes.middle = 0;
+                    columnSizes.right = 0;
+                } else if (hasFullscreenElement) {
+                    columnSizes.left = 0;
+                    columnSizes.middle = 12;
+                    columnSizes.right = 0;
+                } else if ((visibility.detail && state.detail.isFullscreen) ||
+                    visibility.page ||
+                    visibility.searchResults ||
+                    visibility.dataSelection && state.dataSelection.isFullscreen) {
+                    columnSizes.left = 0;
+                    columnSizes.middle = 0;
+                    columnSizes.right = 12;
+                } else {
+                    columnSizes.left = 0;
+                    columnSizes.middle = 12;
+                    columnSizes.right = 12;
+                }
             }
+
+            return columnSizes;
         }
     }
 })();

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -51,15 +51,15 @@
                     visibility.map = !activity.layerSelection &&
                         (
                             state.map.isFullscreen ||
-                            (activity.detail && !state.detail.isInvisible && angular.isObject(state.detail.geometry)) ||
-                            activity.straatbeeld && !state.straatbeeld.isInvisible
+                            (activity.detail && angular.isObject(state.detail.geometry)) ||
+                            activity.straatbeeld
                         );
                 } else {
                     visibility.map = true;
                 }
 
                 visibility.layerSelection = state.layerSelection;
-                visibility.straatbeeld = activity.straatbeeld && !state.straatbeeld.isInvisible;
+                visibility.straatbeeld = activity.straatbeeld;
 
                 if (visibility.straatbeeld && state.straatbeeld.isFullscreen) {
                     visibility.detail = false;
@@ -72,7 +72,7 @@
                     visibility.searchResults = false;
                     visibility.straatbeeld = false;
                 } else {
-                    visibility.detail = activity.detail && !state.detail.isInvisible;
+                    visibility.detail = activity.detail;
                     visibility.page = angular.isString(state.page);
                     visibility.searchResults = activity.searchResults;
                 }

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.js
@@ -72,7 +72,7 @@
                     visibility.searchResults = false;
                     visibility.straatbeeld = false;
                 } else {
-                    visibility.detail = activity.detail;
+                    visibility.detail = activity.detail && !activity.straatbeeld;
                     visibility.page = angular.isString(state.page);
                     visibility.searchResults = activity.searchResults;
                 }

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
@@ -13,6 +13,78 @@ describe('The dashboardColumns factory', function () {
         });
     });
 
+    describe('when determining component activity', function () {
+        it('the map is always active, regardless of input', function () {
+            let activity;
+
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.map).toBe(true);
+
+            delete mockedState.map;
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.map).toBe(true);
+        });
+
+        it('checks if map.layerSelection is true in the state', function () {
+            let activity;
+
+            mockedState.layerSelection = true;
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.layerSelection).toBe(true);
+
+            mockedState.layerSelection = false;
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.layerSelection).toBe(false);
+        });
+
+        it('checks if page is a string', function () {
+            let activity;
+
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.page).toBe(true);
+
+            mockedState.page = null;
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.page).toBe(false);
+        });
+
+        it('checks if search, detail, straatbeeld and dataSelection are objects', function () {
+            let activity;
+
+            // Search
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.searchResults).toBe(false);
+
+            mockedState.search = {query: 'lekker zoeken'};
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.searchResults).toBe(true);
+
+            // Detail
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.detail).toBe(false);
+
+            mockedState.detail = {endpoint: 'https://blah/123'};
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.detail).toBe(true);
+
+            // Straatbeeld
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.straatbeeld).toBe(false);
+
+            mockedState.straatbeeld = {id: 'abc123'};
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.straatbeeld).toBe(true);
+
+            // Data selection
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.dataSelection).toBe(false);
+
+            mockedState.dataSelection = {dataset: 'bag'};
+            activity = dashboardColumns.determineActivity(mockedState);
+            expect(activity.dataSelection).toBe(true);
+        });
+    });
+
     describe('when visiting a page', function () {
         describe('the default non-print version', function () {
             beforeEach(function () {

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
@@ -316,6 +316,28 @@ describe('The dashboardColumns factory', function () {
                 expect(visibility.dataSelection).toBe(false);
             });
 
+            it('detail and straatbeeld can\'t be visible at the same time', function () {
+                // Only straatbeeld is active
+                visibility = dashboardColumns.determineVisibility(mockedState);
+                expect(visibility.straatbeeld).toBe(true);
+                expect(visibility.detail).toBe(false);
+
+                // Only detail is active
+                mockedState.detail = {
+                    endpoint: 'whatever'
+                };
+                delete mockedState.straatbeeld;
+                visibility = dashboardColumns.determineVisibility(mockedState);
+                expect(visibility.straatbeeld).toBe(false);
+                expect(visibility.detail).toBe(true);
+
+                // Both straatbeeld and detail are active
+                mockedState.straatbeeld = {id: 'xyz'};
+                visibility = dashboardColumns.determineVisibility(mockedState);
+                expect(visibility.straatbeeld).toBe(true);
+                expect(visibility.detail).toBe(false);
+            });
+
             it('has the straatbeeld visibile when it has an id', function () {
                 mockedState.straatbeeld = {id: '123'};
                 visibility = dashboardColumns.determineVisibility(mockedState);

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
@@ -238,24 +238,6 @@ describe('The dashboardColumns factory', function () {
                 expect(visibility.dataSelection).toBe(false);
             });
 
-            it('hides the straatbeeld page when the straatbeeld is set invisible', function () {
-                mockedState.straatbeeld = {
-                    id: 'aap',
-                    isInvisible: true
-                };
-                visibility = dashboardColumns.determineVisibility(mockedState);
-                expect(visibility.straatbeeld).toBe(false);
-            });
-
-            it('hides the detail page when the detail is set invisible', function () {
-                mockedState.detail = {
-                    endpoint: [1, 2],
-                    isInvisible: true
-                };
-                visibility = dashboardColumns.determineVisibility(mockedState);
-                expect(visibility.detail).toBe(false);
-            });
-
             it('left column: 0/3, middle column: 1/3, right column 2/3', function () {
                 expect(columnSizes.left).toBe(0);
                 expect(columnSizes.middle).toBe(4);

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
@@ -189,6 +189,17 @@ describe('The dashboardColumns factory', function () {
                 expect(columnSizes.middle).toBe(4);
                 expect(columnSizes.right).toBe(8);
             });
+
+            it('can be shown fullscreen', function () {
+                mockedState.detail.isFullscreen = true;
+
+                visibility = dashboardColumns.determineVisibility(mockedState);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+
+                expect(columnSizes.left).toBe(0);
+                expect(columnSizes.middle).toBe(0);
+                expect(columnSizes.right).toBe(12);
+            });
         });
 
         describe('the print version', function () {
@@ -264,20 +275,21 @@ describe('The dashboardColumns factory', function () {
                 expect(visibility.straatbeeld).toBe(true);
             });
 
-            it('has the straatbeeld solely visibile when it is fullscreen', function () {
-                mockedState.straatbeeld = {location: [1, 5], isFullscreen: true};
-                visibility = dashboardColumns.determineVisibility(mockedState);
-                expect(visibility.straatbeeld).toBe(true);
-                expect(visibility.detail).toBe(false);
-                expect(visibility.page).toBe(false);
-                expect(visibility.searchResults).toBe(false);
-                expect(visibility.map).toBe(false);
-            });
-
             it('left column: 0/3, middle column: 1/3, right column 2/3', function () {
                 expect(columnSizes.left).toBe(0);
                 expect(columnSizes.middle).toBe(4);
                 expect(columnSizes.right).toBe(8);
+            });
+
+            it('can be shown fullscreen', function () {
+                mockedState.straatbeeld.isFullscreen = true;
+
+                visibility = dashboardColumns.determineVisibility(mockedState);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+
+                expect(columnSizes.left).toBe(0);
+                expect(columnSizes.middle).toBe(0);
+                expect(columnSizes.right).toBe(12);
             });
         });
 

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
@@ -19,7 +19,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(visibility, false, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
             });
 
             it('makes the map and page visibile', function () {
@@ -45,7 +45,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
             });
 
             it('makes the page visibile', function () {
@@ -90,7 +90,7 @@ describe('The dashboardColumns factory', function () {
                     mockedState.isPrintMode = false;
 
                     visibility = dashboardColumns.determineVisibility(mockedState);
-                    columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, false);
+                    columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
                 });
 
                 it('makes the map and searchResults visibile', function () {
@@ -116,7 +116,7 @@ describe('The dashboardColumns factory', function () {
                     mockedState.isPrintMode = true;
 
                     visibility = dashboardColumns.determineVisibility(mockedState);
-                    columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, true);
+                    columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
                 });
 
                 it('makes the searchResults visibile', function () {
@@ -152,7 +152,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
             });
 
             it('makes the map and detail page visibile', function () {
@@ -211,7 +211,7 @@ describe('The dashboardColumns factory', function () {
 
             it('left column: 0/3, middle column: 3/3, right column 3/3', function () {
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
 
                 expect(columnSizes.left).toBe(0);
                 expect(columnSizes.middle).toBe(12);
@@ -238,7 +238,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
             });
 
             it('makes the map and straatbeeld visibile', function () {
@@ -286,7 +286,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
             });
 
             it('makes the map and straatbeeld visibile', function () {
@@ -322,7 +322,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
             });
 
             it('makes the layerSelection and map visibile', function () {
@@ -348,7 +348,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
             });
 
             it('makes the layerSelection visibile', function () {
@@ -380,7 +380,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
             });
 
             it('makes the map visibile', function () {
@@ -406,7 +406,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
             });
 
             it('makes the map visibile', function () {
@@ -443,7 +443,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
             });
 
             it('makes the layerSelection and map visibile', function () {
@@ -469,7 +469,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
             });
 
             it('makes the layerSelection visibile', function () {
@@ -512,7 +512,7 @@ describe('The dashboardColumns factory', function () {
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
 
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
             });
 
             it('only shows dataSelection', function () {
@@ -540,7 +540,7 @@ describe('The dashboardColumns factory', function () {
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
 
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
             });
 
             it('shows dataSelectionList and map', function () {
@@ -567,7 +567,7 @@ describe('The dashboardColumns factory', function () {
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
 
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
             });
 
             it('only shows dataSelection', function () {

--- a/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
+++ b/modules/atlas/components/dashboard/dashboard-columns.factory.test.js
@@ -91,7 +91,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('makes the map and page visibile', function () {
@@ -117,7 +117,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('makes the page visibile', function () {
@@ -162,7 +162,7 @@ describe('The dashboardColumns factory', function () {
                     mockedState.isPrintMode = false;
 
                     visibility = dashboardColumns.determineVisibility(mockedState);
-                    columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+                    columnSizes = dashboardColumns.determineColumnSizes(mockedState);
                 });
 
                 it('makes the map and searchResults visibile', function () {
@@ -188,7 +188,7 @@ describe('The dashboardColumns factory', function () {
                     mockedState.isPrintMode = true;
 
                     visibility = dashboardColumns.determineVisibility(mockedState);
-                    columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
+                    columnSizes = dashboardColumns.determineColumnSizes(mockedState);
                 });
 
                 it('makes the searchResults visibile', function () {
@@ -224,7 +224,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('makes the map and detail page visibile', function () {
@@ -266,7 +266,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.detail.isFullscreen = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
 
                 expect(columnSizes.left).toBe(0);
                 expect(columnSizes.middle).toBe(0);
@@ -293,8 +293,7 @@ describe('The dashboardColumns factory', function () {
             });
 
             it('left column: 0/3, middle column: 3/3, right column 3/3', function () {
-                visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
 
                 expect(columnSizes.left).toBe(0);
                 expect(columnSizes.middle).toBe(12);
@@ -321,7 +320,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('makes the map and straatbeeld visibile', function () {
@@ -356,8 +355,7 @@ describe('The dashboardColumns factory', function () {
             it('can be shown fullscreen', function () {
                 mockedState.straatbeeld.isFullscreen = true;
 
-                visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
 
                 expect(columnSizes.left).toBe(0);
                 expect(columnSizes.middle).toBe(0);
@@ -370,7 +368,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('makes the map and straatbeeld visibile', function () {
@@ -406,7 +404,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('makes the layerSelection and map visibile', function () {
@@ -432,7 +430,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('makes the layerSelection visibile', function () {
@@ -464,7 +462,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('makes the map visibile', function () {
@@ -490,7 +488,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('makes the map visibile', function () {
@@ -527,7 +525,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('makes the layerSelection and map visibile', function () {
@@ -553,7 +551,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('makes the layerSelection visibile', function () {
@@ -595,8 +593,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = false;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('only shows dataSelection', function () {
@@ -624,7 +621,7 @@ describe('The dashboardColumns factory', function () {
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
 
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, false);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('shows dataSelectionList and map', function () {
@@ -650,8 +647,7 @@ describe('The dashboardColumns factory', function () {
                 mockedState.isPrintMode = true;
 
                 visibility = dashboardColumns.determineVisibility(mockedState);
-
-                columnSizes = dashboardColumns.determineColumnSizes(mockedState, visibility, true);
+                columnSizes = dashboardColumns.determineColumnSizes(mockedState);
             });
 
             it('only shows dataSelection', function () {

--- a/modules/atlas/components/dashboard/dashboard.component.js
+++ b/modules/atlas/components/dashboard/dashboard.component.js
@@ -42,7 +42,6 @@
             vm.columnSizes = dashboardColumns.determineColumnSizes(
                 state,
                 vm.visibility,
-                vm.isFullscreen,
                 vm.isPrintMode
             );
 

--- a/modules/atlas/components/dashboard/dashboard.component.js
+++ b/modules/atlas/components/dashboard/dashboard.component.js
@@ -12,7 +12,7 @@
     DpDashboardController.$inject = ['store', 'dashboardColumns'];
 
     function DpDashboardController (store, dashboardColumns) {
-        var vm = this;
+        let vm = this;
 
         vm.store = store;
 
@@ -20,10 +20,11 @@
         setLayout();
 
         function setLayout () {
-            var state = store.getState();
+            const state = store.getState();
 
             vm.isFullscreen = state.map.isFullscreen || (state.straatbeeld && state.straatbeeld.isFullscreen);
 
+            vm.activity = dashboardColumns.determineVisibility(state);
             vm.visibility = dashboardColumns.determineVisibility(state);
 
             vm.isPrintMode = state.isPrintMode;

--- a/modules/atlas/components/dashboard/dashboard.component.js
+++ b/modules/atlas/components/dashboard/dashboard.component.js
@@ -22,8 +22,6 @@
         function setLayout () {
             const state = store.getState();
 
-            vm.isFullscreen = state.map.isFullscreen || (state.straatbeeld && state.straatbeeld.isFullscreen);
-
             vm.activity = dashboardColumns.determineVisibility(state);
             vm.visibility = dashboardColumns.determineVisibility(state);
 

--- a/modules/atlas/components/dashboard/dashboard.component.js
+++ b/modules/atlas/components/dashboard/dashboard.component.js
@@ -22,7 +22,7 @@
         function setLayout () {
             const state = store.getState();
 
-            vm.activity = dashboardColumns.determineVisibility(state);
+            vm.activity = dashboardColumns.determineActivity(state);
             vm.visibility = dashboardColumns.determineVisibility(state);
 
             vm.isPrintMode = state.isPrintMode;

--- a/modules/atlas/components/dashboard/dashboard.component.js
+++ b/modules/atlas/components/dashboard/dashboard.component.js
@@ -9,15 +9,17 @@
             controllerAs: 'vm'
         });
 
-    DpDashboardController.$inject = ['store', 'dashboardColumns'];
+    DpDashboardController.$inject = ['$scope', 'store', 'dashboardColumns'];
 
-    function DpDashboardController (store, dashboardColumns) {
+    function DpDashboardController ($scope, store, dashboardColumns) {
         let vm = this;
 
         vm.store = store;
 
         store.subscribe(setLayout);
         setLayout();
+
+        $scope.$watch(() => dashboardColumns.determineVisibility(store.getState()).httpStatus, setLayout);
 
         function setLayout () {
             const state = store.getState();

--- a/modules/atlas/components/dashboard/dashboard.component.js
+++ b/modules/atlas/components/dashboard/dashboard.component.js
@@ -39,11 +39,7 @@
                     vm.visibility.dataSelection
                 );
 
-            vm.columnSizes = dashboardColumns.determineColumnSizes(
-                state,
-                vm.visibility,
-                vm.isPrintMode
-            );
+            vm.columnSizes = dashboardColumns.determineColumnSizes(state);
 
             // Needed for the dp-scrollable-content directive
             vm.pageName = state.page;

--- a/modules/atlas/components/dashboard/dashboard.component.test.js
+++ b/modules/atlas/components/dashboard/dashboard.component.test.js
@@ -141,18 +141,18 @@ describe('The dashboard component', function () {
         it('displays the columns according to the column size', function () {
             component = getComponent();
 
-            expect(component.find('.qa-dashboard__layer-selection').length).toBe(1);
-            expect(component.find('.qa-dashboard__map').length).toBe(1);
-            expect(component.find('.qa-dashboard__content').length).toBe(1);
+            expect(component.find('.qa-dashboard__layer-selection').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__map').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(false);
         });
 
         it('does not display a column on zero size', function () {
             mockedColumnSizes.left = 0;
             component = getComponent();
 
-            expect(component.find('.qa-dashboard__layer-selection').length).toBe(0);
-            expect(component.find('.qa-dashboard__map').length).toBe(1);
-            expect(component.find('.qa-dashboard__content').length).toBe(1);
+            expect(component.find('.qa-dashboard__layer-selection').hasClass('ng-hide')).toBe(true);
+            expect(component.find('.qa-dashboard__map').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(false);
         });
 
         it('does not display a column on missing size', function () {
@@ -161,9 +161,9 @@ describe('The dashboard component', function () {
             delete mockedColumnSizes.right;
             component = getComponent();
 
-            expect(component.find('.qa-dashboard__layer-selection').length).toBe(0);
-            expect(component.find('.qa-dashboard__map').length).toBe(0);
-            expect(component.find('.qa-dashboard__content').length).toBe(0);
+            expect(component.find('.qa-dashboard__layer-selection').hasClass('ng-hide')).toBe(true);
+            expect(component.find('.qa-dashboard__map').hasClass('ng-hide')).toBe(true);
+            expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(true);
         });
 
         it('adds the correct class according to the column size', function () {
@@ -208,10 +208,10 @@ describe('The dashboard component', function () {
             });
             component = getComponent();
 
-            expect(component.find('.qa-dashboard__layer-selection').length).toBe(1);
-            expect(component.find('.qa-dashboard__map').length).toBe(0);
-            expect(component.find('.qa-dashboard__straatbeeld').length).toBe(1);
-            expect(component.find('.qa-dashboard__content').length).toBe(1);
+            expect(component.find('.qa-dashboard__layer-selection').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__map').hasClass('ng-hide')).toBe(true);
+            expect(component.find('.qa-dashboard__straatbeeld').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(false);
         });
 
         it('displays a normal straatbeeld on straatbeeld.isFullscreen = false', function () {
@@ -224,10 +224,10 @@ describe('The dashboard component', function () {
             });
             component = getComponent();
 
-            expect(component.find('.qa-dashboard__layer-selection').length).toBe(1);
-            expect(component.find('.qa-dashboard__map').length).toBe(0);
-            expect(component.find('.qa-dashboard__straatbeeld').length).toBe(0);
-            expect(component.find('.qa-dashboard__content').length).toBe(1);
+            expect(component.find('.qa-dashboard__layer-selection').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__map').hasClass('ng-hide')).toBe(true);
+            expect(component.find('.qa-dashboard__straatbeeld').hasClass('ng-hide')).toBe(true);
+            expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(false);
         });
     });
 });

--- a/modules/atlas/components/dashboard/dashboard.component.test.js
+++ b/modules/atlas/components/dashboard/dashboard.component.test.js
@@ -137,18 +137,18 @@ describe('The dashboard component', function () {
         it('displays the columns according to the column size', function () {
             component = getComponent();
 
-            expect(component.find('.qa-dashboard__layer-selection').hasClass('ng-hide')).toBe(false);
-            expect(component.find('.qa-dashboard__map').hasClass('ng-hide')).toBe(false);
-            expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__column--left').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__column--middle').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__column--right').hasClass('ng-hide')).toBe(false);
         });
 
         it('does not display a column on zero size', function () {
             mockedColumnSizes.left = 0;
             component = getComponent();
 
-            expect(component.find('.qa-dashboard__layer-selection').hasClass('ng-hide')).toBe(true);
-            expect(component.find('.qa-dashboard__map').hasClass('ng-hide')).toBe(false);
-            expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__column--left').hasClass('ng-hide')).toBe(true);
+            expect(component.find('.qa-dashboard__column--middle').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__column--right').hasClass('ng-hide')).toBe(false);
         });
 
         it('does not display a column on missing size', function () {
@@ -157,75 +157,17 @@ describe('The dashboard component', function () {
             delete mockedColumnSizes.right;
             component = getComponent();
 
-            expect(component.find('.qa-dashboard__layer-selection').hasClass('ng-hide')).toBe(true);
-            expect(component.find('.qa-dashboard__map').hasClass('ng-hide')).toBe(true);
-            expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(true);
+            expect(component.find('.qa-dashboard__column--left').hasClass('ng-hide')).toBe(true);
+            expect(component.find('.qa-dashboard__column--middle').hasClass('ng-hide')).toBe(true);
+            expect(component.find('.qa-dashboard__column--right').hasClass('ng-hide')).toBe(true);
         });
 
         it('adds the correct class according to the column size', function () {
             component = getComponent();
 
-            expect(component.find('.qa-dashboard__layer-selection').attr('class')).toContain('u-col-sm--1');
-            expect(component.find('.qa-dashboard__map').attr('class')).toContain('u-col-sm--2');
-            expect(component.find('.qa-dashboard__content').attr('class')).toContain('u-col-sm--3');
-        });
-    });
-
-    describe('straatbeeld', function () {
-        var component,
-            mockedVisibility,
-            mockedColumnSizes;
-
-        beforeEach(function () {
-            mockedVisibility = {
-                httpStatus: false,
-                map: false,
-                straatbeeld: true
-            };
-            mockedColumnSizes = {
-                left: 1,
-                middle: 2,
-                right: 3
-            };
-
-            spyOn(dashboardColumns, 'determineVisibility').and.returnValue(mockedVisibility);
-            spyOn(dashboardColumns, 'determineColumnSizes').and.returnValue(mockedColumnSizes);
-        });
-
-        it('displays a fullscreen straatbeeld on straatbeeld.isFullscreen = true', function () {
-            spyOn(store, 'getState').and.returnValue({
-                straatbeeld: {
-                    isFullscreen: true
-                },
-                map: {
-                }
-            });
-            component = getComponent();
-
-            expect(component.find('.qa-dashboard__layer-selection').hasClass('ng-hide')).toBe(false);
-            expect(component.find('.qa-dashboard__map').length).toBe(0);
-            expect(component.find('.qa-dashboard__straatbeeld').length).toBe(1);
-            expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(false);
-        });
-
-        it('displays a normal straatbeeld on straatbeeld.isFullscreen = false', function () {
-            mockedVisibility.map = true;
-
-            spyOn(store, 'getState').and.returnValue({
-                straatbeeld: {
-                    isFullscreen: false
-                },
-                map: {
-                }
-            });
-            component = getComponent();
-
-            // This is the middle column which should contain the map and not the straatbeeld
-            expect(component.find('.qa-dashboard__map').length).toBe(1);
-            expect(component.find('.qa-dashboard__straatbeeld').length).toBe(0);
-
-            // The straatbeeld is in the right column (which has the .qa-dashboard__content class)
-            expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__column--left').attr('class')).toContain('u-col-sm--1');
+            expect(component.find('.qa-dashboard__column--middle').attr('class')).toContain('u-col-sm--2');
+            expect(component.find('.qa-dashboard__column--right').attr('class')).toContain('u-col-sm--3');
         });
     });
 });

--- a/modules/atlas/components/dashboard/dashboard.component.test.js
+++ b/modules/atlas/components/dashboard/dashboard.component.test.js
@@ -112,6 +112,26 @@ describe('The dashboard component', function () {
 
             expect(component.find('.c-dashboard__body').attr('class')).toContain('c-dashboard__body--error');
         });
+
+        it('watches for changes to error message and rerenders the dashboard when needed', function () {
+            // Start without the error message
+            component = getComponent();
+            expect(component.find('dp-api-error').length).toBe(0);
+
+            // Set the error message
+            mockedVisibility = {
+                httpStatus: true
+            };
+            $rootScope.$apply();
+            expect(component.find('dp-api-error').length).toBe(1);
+
+            // Remove the message again
+            mockedVisibility = {
+                httpStatus: false
+            };
+            $rootScope.$apply();
+            expect(component.find('dp-api-error').length).toBe(0);
+        });
     });
 
     describe('column sizes', function () {

--- a/modules/atlas/components/dashboard/dashboard.component.test.js
+++ b/modules/atlas/components/dashboard/dashboard.component.test.js
@@ -203,12 +203,14 @@ describe('The dashboard component', function () {
             component = getComponent();
 
             expect(component.find('.qa-dashboard__layer-selection').hasClass('ng-hide')).toBe(false);
-            expect(component.find('.qa-dashboard__map').hasClass('ng-hide')).toBe(true);
-            expect(component.find('.qa-dashboard__straatbeeld').hasClass('ng-hide')).toBe(false);
+            expect(component.find('.qa-dashboard__map').length).toBe(0);
+            expect(component.find('.qa-dashboard__straatbeeld').length).toBe(1);
             expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(false);
         });
 
         it('displays a normal straatbeeld on straatbeeld.isFullscreen = false', function () {
+            mockedVisibility.map = true;
+
             spyOn(store, 'getState').and.returnValue({
                 straatbeeld: {
                     isFullscreen: false
@@ -218,9 +220,11 @@ describe('The dashboard component', function () {
             });
             component = getComponent();
 
-            expect(component.find('.qa-dashboard__layer-selection').hasClass('ng-hide')).toBe(false);
-            expect(component.find('.qa-dashboard__map').hasClass('ng-hide')).toBe(true);
-            expect(component.find('.qa-dashboard__straatbeeld').hasClass('ng-hide')).toBe(true);
+            // This is the middle column which should contain the map and not the straatbeeld
+            expect(component.find('.qa-dashboard__map').length).toBe(1);
+            expect(component.find('.qa-dashboard__straatbeeld').length).toBe(0);
+
+            // The straatbeeld is in the right column (which has the .qa-dashboard__content class)
             expect(component.find('.qa-dashboard__content').hasClass('ng-hide')).toBe(false);
         });
     });

--- a/modules/atlas/components/dashboard/dashboard.component.test.js
+++ b/modules/atlas/components/dashboard/dashboard.component.test.js
@@ -93,9 +93,7 @@ describe('The dashboard component', function () {
     describe('error message', function () {
         var component,
             mockedVisibility = {
-                httpStatus: {
-                    hasErrors: false
-                }
+                httpStatus: false
             };
 
         beforeEach(function () {
@@ -109,7 +107,7 @@ describe('The dashboard component', function () {
         });
 
         it('when shown, flags the dashboard body', function () {
-            mockedVisibility.httpStatus.hasErrors = true;
+            mockedVisibility.httpStatus = true;
             component = getComponent();
 
             expect(component.find('.c-dashboard__body').attr('class')).toContain('c-dashboard__body--error');
@@ -123,9 +121,7 @@ describe('The dashboard component', function () {
 
         beforeEach(function () {
             mockedVisibility = {
-                httpStatus: {
-                    hasErrors: false
-                },
+                httpStatus: false,
                 map: true
             };
             mockedColumnSizes = {
@@ -182,9 +178,7 @@ describe('The dashboard component', function () {
 
         beforeEach(function () {
             mockedVisibility = {
-                httpStatus: {
-                    hasErrors: false
-                },
+                httpStatus: false,
                 map: false,
                 straatbeeld: true
             };

--- a/modules/atlas/components/dashboard/dashboard.component.test.js
+++ b/modules/atlas/components/dashboard/dashboard.component.test.js
@@ -97,7 +97,7 @@ describe('The dashboard component', function () {
             };
 
         beforeEach(function () {
-            spyOn(dashboardColumns, 'determineVisibility').and.returnValue(mockedVisibility);
+            spyOn(dashboardColumns, 'determineVisibility').and.callFake(() => mockedVisibility);
         });
 
         it('when not shown, does not flags the dashboard body', function () {
@@ -116,6 +116,10 @@ describe('The dashboard component', function () {
         it('watches for changes to error message and rerenders the dashboard when needed', function () {
             // Start without the error message
             component = getComponent();
+            mockedVisibility = {
+                httpStatus: false
+            };
+            $rootScope.$apply();
             expect(component.find('dp-api-error').length).toBe(0);
 
             // Set the error message

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -43,11 +43,16 @@
                     </div>
                 </div>
 
-                <!-- Map -->
-                <div ng-show="vm.columnSizes.middle && vm.visibility.map"
-                     class="qa-dashboard__map c-dashboard__column"
-                     ng-class="'u-col-sm--' + vm.columnSizes.middle">
+                <!-- Middle column -->
+                <div
+                    ng-show="vm.columnSizes.middle && (vm.visibility.map || (vm.visibility.straatbeeld && vm.isFullscreen))"
+                    class="c-dashboard__column u-col-sm--{{vm.columnSizes.middle}}"
+                    ng-class="{
+                        'qa-dashboard__map': vm.visibility.map,
+                        'qa-dashboard__straatbeeld': vm.visibility.straatbeeld && vm.isFullscreen
+                    }">
 
+                    <!-- Map -->
                     <div ng-if="vm.activity.map" ng-controller="MapController as map">
                         <dp-map
                             ng-show="vm.visibility.map"
@@ -56,15 +61,10 @@
                             markers="map.markers">
                         </dp-map>
                     </div>
-                </div>
 
-                <!-- Fullscreen Straatbeeld -->
-                <div ng-show="vm.columnSizes.middle && vm.visibility.straatbeeld && vm.isFullscreen"
-                     class="qa-dashboard__straatbeeld c-dashboard__column"
-                     ng-class="'u-col-sm--' + vm.columnSizes.middle">
-
+                    <!-- Fullscreen straatbeeld -->
                     <div ng-if="vm.activity.straatbeeld" ng-controller="StraatbeeldController as straatbeeld"
-                        class="u-dashboard--full-height">
+                         class="u-dashboard--full-height">
                         <dp-straatbeeld
                             ng-show="vm.visibility.straatbeeld"
                             state="straatbeeld.straatbeeldState"

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -33,9 +33,8 @@
                     ng-class="'u-col-sm--' + vm.columnSizes.left">
 
                     <!-- Layer selection -->
-                    <div ng-if="vm.activity.layerSelection" ng-controller="LayerSelectionController as layerSelection">
+                    <div ng-if="vm.activity.layerSelection" ng-show="vm.visibility.layerSelection" ng-controller="LayerSelectionController as layerSelection">
                         <dp-layer-selection
-                            ng-show="vm.visibility.layerSelection"
                             base-layer="{{layerSelection.baseLayer}}"
                             overlays="layerSelection.overlays"
                             zoom="layerSelection.zoom">
@@ -48,9 +47,8 @@
                     class="c-dashboard__column u-col-sm--{{vm.columnSizes.middle}} qa-dashboard__column--middle">
 
                     <!-- Map -->
-                    <div ng-if="vm.activity.map" ng-controller="MapController as map">
+                    <div ng-if="vm.activity.map" ng-show="vm.visibility.map" ng-controller="MapController as map">
                         <dp-map
-                            ng-show="vm.visibility.map"
                             map-state="map.mapState"
                             show-layer-selection="map.showLayerSelection"
                             markers="map.markers">
@@ -66,9 +64,8 @@
                     class="c-dashboard__column c-dashboard__content u-col-sm--{{vm.columnSizes.right}} qa-dashboard__column--right">
 
                     <!-- Detail -->
-                    <div ng-if="vm.activity.detail" ng-controller="DetailController as detail">
+                    <div ng-if="vm.activity.detail" ng-show="vm.visibility.detail" ng-controller="DetailController as detail">
                         <dp-detail
-                            ng-show="vm.visibility.detail"
                             endpoint="{{detail.endpoint}}"
                             reload="detail.reload"
                             is-loading="detail.isLoading">
@@ -76,17 +73,13 @@
                     </div>
 
                     <!-- Page -->
-                    <div ng-if="vm.activity.page" ng-controller="PageController as page">
-                        <dp-page
-                            ng-show="vm.visibility.page"
-                            name="{{page.pageName}}">
-                        </dp-page>
+                    <div ng-if="vm.activity.page" ng-show="vm.visibility.page" ng-controller="PageController as page">
+                        <dp-page name="{{page.pageName}}"></dp-page>
                     </div>
 
                     <!-- Search results -->
-                    <div ng-if="vm.activity.searchResults" ng-controller="SearchResultsController as searchResults">
+                    <div ng-if="vm.activity.searchResults" ng-show="vm.visibility.searchResults" ng-controller="SearchResultsController as searchResults">
                         <dp-search-results
-                            ng-show="vm.visibility.searchResults"
                             is-loading="searchResults.isLoading"
                             query="{{searchResults.query}}"
                             location="searchResults.location"
@@ -96,24 +89,20 @@
                     </div>
 
                     <!-- Straatbeeld -->
-                    <div ng-if="vm.activity.straatbeeld"
+                    <div ng-if="vm.activity.straatbeeld" ng-show="vm.visibility.straatbeeld"
                         ng-controller="StraatbeeldController as straatbeeld"
                         class="u-dashboard--full-height">
 
                         <!--Resize straatbeeld when any of printMode, errorMode or fullscreen changes-->
                         <dp-straatbeeld
-                            ng-show="vm.visibility.straatbeeld"
                             state="straatbeeld.straatbeeldState"
                             resize="[vm.isPrintMode, vm.visibility.httpStatus, vm.visibility.straatbeeld, vm.columnSizes.right]">
                         </dp-straatbeeld>
                     </div>
 
                     <!-- Data selection -->
-                    <div ng-if="vm.activity.dataSelection" ng-controller="DataSelectionController as dataSelection">
-                        <dp-data-selection
-                            ng-show="vm.visibility.dataSelection"
-                            state="dataSelection.dataSelectionState">
-                        </dp-data-selection>
+                    <div ng-if="vm.activity.dataSelection" ng-show="vm.visibility.dataSelection" ng-controller="DataSelectionController as dataSelection">
+                        <dp-data-selection state="dataSelection.dataSelectionState"></dp-data-selection>
                     </div>
                 </div>
             </div>

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -27,12 +27,12 @@
 
             <!-- Columns -->
             <div class="u-row">
-
-                <!-- Layer selection -->
+                <!-- Left column -->
                 <div ng-show="vm.columnSizes.left"
                     class="qa-dashboard__layer-selection c-dashboard__column"
                     ng-class="'u-col-sm--' + vm.columnSizes.left">
 
+                    <!-- Layer selection -->
                     <div ng-if="vm.activity.layerSelection" ng-controller="LayerSelectionController as layerSelection">
                         <dp-layer-selection
                             ng-show="vm.visibility.layerSelection"
@@ -61,16 +61,6 @@
                             markers="map.markers">
                         </dp-map>
                     </div>
-
-                    <!-- Fullscreen straatbeeld -->
-                    <div ng-if="vm.activity.straatbeeld" ng-controller="StraatbeeldController as straatbeeld"
-                         class="u-dashboard--full-height">
-                        <dp-straatbeeld
-                            ng-show="vm.visibility.straatbeeld"
-                            state="straatbeeld.straatbeeldState"
-                            resize="[vm.isPrintMode, vm.visibility.httpStatus]">
-                        </dp-straatbeeld>
-                    </div>
                 </div>
 
                 <!-- Right column -->
@@ -87,7 +77,8 @@
                             ng-show="vm.visibility.detail"
                             endpoint="{{detail.endpoint}}"
                             reload="detail.reload"
-                            is-loading="detail.isLoading"></dp-detail>
+                            is-loading="detail.isLoading">
+                        </dp-detail>
                     </div>
 
                     <!-- Page -->
@@ -111,7 +102,7 @@
                     </div>
 
                     <!-- Straatbeeld -->
-                    <div ng-if="vm.activity.straatbeeld && !vm.isFullscreen"
+                    <div ng-if="vm.activity.straatbeeld"
                         ng-controller="StraatbeeldController as straatbeeld"
                         class="u-dashboard--full-height">
 

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -14,14 +14,14 @@
     <div ng-if="vm.isCatalogus" class="qa-dashboard__catalogus-header c-dashboard__heading">
         <dp-cards-header query="{{vm.dataSelectionState.query}}"></dp-cards-header>
     </div>
-
+{{vm.visibility.httpStatus}}
     <!-- Body -->
     <div class="c-dashboard__body"
-        ng-class="{ 'c-dashboard__body--error': vm.visibility.httpStatus.hasErrors }">
+        ng-class="{ 'c-dashboard__body--error': vm.visibility.httpStatus }">
         <div class="u-grid">
 
             <!-- Error message -->
-            <div ng-if="vm.visibility.httpStatus.hasErrors" class="c-dashboard__error">
+            <div ng-if="vm.visibility.httpStatus" class="c-dashboard__error">
                 <dp-api-error></dp-api-error>
             </div>
 
@@ -68,7 +68,7 @@
                         <dp-straatbeeld
                             ng-show="vm.visibility.straatbeeld"
                             state="straatbeeld.straatbeeldState"
-                            resize="[vm.isPrintMode, vm.visibility.httpStatus.hasErrors]">
+                            resize="[vm.isPrintMode, vm.visibility.httpStatus]">
                         </dp-straatbeeld>
                     </div>
                 </div>
@@ -119,7 +119,7 @@
                         <dp-straatbeeld
                             ng-show="vm.visibility.straatbeeld"
                             state="straatbeeld.straatbeeldState"
-                            resize="[vm.isPrintMode, vm.visibility.httpStatus.hasErrors]">
+                            resize="[vm.isPrintMode, vm.visibility.httpStatus]">
                         </dp-straatbeeld>
                     </div>
 

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -104,7 +104,7 @@
                         <dp-straatbeeld
                             ng-show="vm.visibility.straatbeeld"
                             state="straatbeeld.straatbeeldState"
-                            resize="[vm.isPrintMode, vm.visibility.httpStatus, vm.visibility.straatbeeld, straatbeeld.straatbeeldState.isFullscreen]">
+                            resize="[vm.isPrintMode, vm.visibility.httpStatus, vm.visibility.straatbeeld, vm.columnSizes.right]">
                         </dp-straatbeeld>
                     </div>
 

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -100,11 +100,11 @@
                         ng-controller="StraatbeeldController as straatbeeld"
                         class="u-dashboard--full-height">
 
-                        <!--Resize straatbeeld when any of printMode or errorMode changes-->
+                        <!--Resize straatbeeld when any of printMode, errorMode or fullscreen changes-->
                         <dp-straatbeeld
                             ng-show="vm.visibility.straatbeeld"
                             state="straatbeeld.straatbeeldState"
-                            resize="[vm.isPrintMode, vm.visibility.httpStatus]">
+                            resize="[vm.isPrintMode, vm.visibility.httpStatus, straatbeeld.straatbeeldState.isFullscreen]">
                         </dp-straatbeeld>
                     </div>
 

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -18,7 +18,6 @@
     <!-- Body -->
     <div class="c-dashboard__body"
         ng-class="{ 'c-dashboard__body--error': vm.visibility.httpStatus.hasErrors }">
-
         <div class="u-grid">
 
             <!-- Error message -->
@@ -30,41 +29,44 @@
             <div class="u-row">
 
                 <!-- Layer selection -->
-                <div ng-if="vm.columnSizes.left"
+                <div ng-show="vm.columnSizes.left"
                     class="qa-dashboard__layer-selection c-dashboard__column"
                     ng-class="'u-col-sm--' + vm.columnSizes.left">
 
-                    <div ng-controller="LayerSelectionController as vm">
-
+                    <div ng-if="vm.activity.layerSelection" ng-controller="LayerSelectionController as layerSelection">
                         <dp-layer-selection
-                            base-layer="{{vm.baseLayer}}"
-                            overlays="vm.overlays"
-                            zoom="vm.zoom"></dp-layer-selection>
+                            ng-show="vm.visibility.layerSelection"
+                            base-layer="{{layerSelection.baseLayer}}"
+                            overlays="layerSelection.overlays"
+                            zoom="layerSelection.zoom">
+                        </dp-layer-selection>
                     </div>
                 </div>
 
                 <!-- Map -->
-                <div ng-if="vm.columnSizes.middle && vm.visibility.map"
+                <div ng-show="vm.columnSizes.middle && vm.visibility.map"
                      class="qa-dashboard__map c-dashboard__column"
                      ng-class="'u-col-sm--' + vm.columnSizes.middle">
 
-                    <div ng-controller="MapController as vm">
-                        <!-- ng-if="vm.visibility.map" -->
+                    <div ng-if="vm.activity.map" ng-controller="MapController as map">
                         <dp-map
-                            map-state="vm.mapState"
-                            show-layer-selection="vm.showLayerSelection"
-                            markers="vm.markers"></dp-map>
+                            ng-show="vm.visibility.map"
+                            map-state="map.mapState"
+                            show-layer-selection="map.showLayerSelection"
+                            markers="map.markers">
+                        </dp-map>
                     </div>
                 </div>
 
                 <!-- Fullscreen Straatbeeld -->
-                <div ng-if="vm.columnSizes.middle && vm.visibility.straatbeeld && vm.isFullscreen"
+                <div ng-show="vm.columnSizes.middle && vm.visibility.straatbeeld && vm.isFullscreen"
                      class="qa-dashboard__straatbeeld c-dashboard__column"
                      ng-class="'u-col-sm--' + vm.columnSizes.middle">
 
-                    <div ng-controller="StraatbeeldController as straatbeeld"
-                         class="u-dashboard--full-height">
+                    <div ng-if="vm.activity.straatbeeld" ng-controller="StraatbeeldController as straatbeeld"
+                        class="u-dashboard--full-height">
                         <dp-straatbeeld
+                            ng-show="vm.visibility.straatbeeld"
                             state="straatbeeld.straatbeeldState"
                             resize="[vm.isPrintMode, vm.visibility.httpStatus.hasErrors]">
                         </dp-straatbeeld>
@@ -72,7 +74,7 @@
                 </div>
 
                 <!-- Content -->
-                <div ng-if="vm.columnSizes.right"
+                <div ng-show="vm.columnSizes.right"
                     dp-scrollable-content
                     visibility="vm.visibility"
                     page-name="{{vm.pageName}}"
@@ -80,43 +82,53 @@
                     ng-class="'u-col-sm--' + vm.columnSizes.right">
 
                     <!-- Detail -->
-                    <div ng-if="vm.visibility.detail" ng-controller="DetailController as vm">
+                    <div ng-if="vm.activity.detail" ng-controller="DetailController as detail">
                         <dp-detail
-                            endpoint="{{vm.endpoint}}"
-                            reload="vm.reload"
-                            is-loading="vm.isLoading"></dp-detail>
+                            ng-show="vm.visibility.detail"
+                            endpoint="{{detail.endpoint}}"
+                            reload="detail.reload"
+                            is-loading="detail.isLoading"></dp-detail>
                     </div>
 
                     <!-- Page -->
-                    <div ng-if="vm.visibility.page" ng-controller="PageController as vm">
-                        <dp-page name="{{vm.pageName}}"></dp-page>
+                    <div ng-if="vm.activity.page" ng-controller="PageController as page">
+                        <dp-page
+                            ng-show="vm.visibility.page"
+                            name="{{page.pageName}}">
+                        </dp-page>
                     </div>
 
                     <!-- Search results -->
-                    <div ng-if="vm.visibility.searchResults" ng-controller="SearchResultsController as vm">
+                    <div ng-if="vm.activity.searchResults" ng-controller="SearchResultsController as searchResults">
                         <dp-search-results
-                            is-loading="vm.isLoading"
-                            query="{{vm.query}}"
-                            location="vm.location"
-                            category="{{vm.category}}"
-                            number-of-results="vm.numberOfResults"></dp-search-results>
+                            ng-show="vm.visibility.searchResults"
+                            is-loading="searchResults.isLoading"
+                            query="{{searchResults.query}}"
+                            location="searchResults.location"
+                            category="{{searchResults.category}}"
+                            number-of-results="searchResults.numberOfResults">
+                        </dp-search-results>
                     </div>
 
                     <!-- Straatbeeld -->
-                    <div ng-if="vm.visibility.straatbeeld && !vm.isFullscreen"
-                         ng-controller="StraatbeeldController as straatbeeld"
-                       class="u-dashboard--full-height">
+                    <div ng-if="vm.activity.straatbeeld && !vm.isFullscreen"
+                        ng-controller="StraatbeeldController as straatbeeld"
+                        class="u-dashboard--full-height">
 
                         <!--Resize straatbeeld when any of printMode or errorMode changes-->
                         <dp-straatbeeld
+                            ng-show="vm.visibility.straatbeeld"
                             state="straatbeeld.straatbeeldState"
                             resize="[vm.isPrintMode, vm.visibility.httpStatus.hasErrors]">
                         </dp-straatbeeld>
                     </div>
 
                     <!-- Data selection -->
-                    <div ng-if="vm.visibility.dataSelection" ng-controller="DataSelectionController as vm">
-                        <dp-data-selection state="vm.dataSelectionState"></dp-data-selection>
+                    <div ng-if="vm.activity.dataSelection" ng-controller="DataSelectionController as dataSelection">
+                        <dp-data-selection
+                            ng-show="vm.visibility.dataSelection"
+                            state="dataSelection.dataSelectionState">
+                        </dp-data-selection>
                     </div>
                 </div>
             </div>

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -44,8 +44,7 @@
                 </div>
 
                 <!-- Middle column -->
-                <div
-                    ng-show="vm.columnSizes.middle"
+                <div ng-show="vm.columnSizes.middle"
                     class="c-dashboard__column u-col-sm--{{vm.columnSizes.middle}} qa-dashboard__column--middle">
 
                     <!-- Map -->

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -45,7 +45,7 @@
 
                 <!-- Middle column -->
                 <div
-                    ng-show="vm.columnSizes.middle && (vm.visibility.map || (vm.visibility.straatbeeld && vm.isFullscreen))"
+                    ng-show="vm.columnSizes.middle"
                     class="c-dashboard__column u-col-sm--{{vm.columnSizes.middle}}"
                     ng-class="{
                         'qa-dashboard__map': vm.visibility.map,
@@ -73,7 +73,7 @@
                     </div>
                 </div>
 
-                <!-- Content -->
+                <!-- Right column -->
                 <div ng-show="vm.columnSizes.right"
                     dp-scrollable-content
                     visibility="vm.visibility"

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -104,7 +104,7 @@
                         <dp-straatbeeld
                             ng-show="vm.visibility.straatbeeld"
                             state="straatbeeld.straatbeeldState"
-                            resize="[vm.isPrintMode, vm.visibility.httpStatus, straatbeeld.straatbeeldState.isFullscreen]">
+                            resize="[vm.isPrintMode, vm.visibility.httpStatus, vm.visibility.straatbeeld, straatbeeld.straatbeeldState.isFullscreen]">
                         </dp-straatbeeld>
                     </div>
 

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -29,7 +29,7 @@
             <div class="u-row">
                 <!-- Left column -->
                 <div ng-show="vm.columnSizes.left"
-                    class="qa-dashboard__layer-selection c-dashboard__column"
+                    class="qa-dashboard__column--left c-dashboard__column"
                     ng-class="'u-col-sm--' + vm.columnSizes.left">
 
                     <!-- Layer selection -->
@@ -46,11 +46,7 @@
                 <!-- Middle column -->
                 <div
                     ng-show="vm.columnSizes.middle"
-                    class="c-dashboard__column u-col-sm--{{vm.columnSizes.middle}}"
-                    ng-class="{
-                        'qa-dashboard__map': vm.visibility.map,
-                        'qa-dashboard__straatbeeld': vm.visibility.straatbeeld && vm.isFullscreen
-                    }">
+                    class="c-dashboard__column u-col-sm--{{vm.columnSizes.middle}} qa-dashboard__column--middle">
 
                     <!-- Map -->
                     <div ng-if="vm.activity.map" ng-controller="MapController as map">
@@ -68,8 +64,7 @@
                     dp-scrollable-content
                     visibility="vm.visibility"
                     page-name="{{vm.pageName}}"
-                    class="qa-dashboard__content c-dashboard__column c-dashboard__content"
-                    ng-class="'u-col-sm--' + vm.columnSizes.right">
+                    class="c-dashboard__column c-dashboard__content u-col-sm--{{vm.columnSizes.right}} qa-dashboard__column--right">
 
                     <!-- Detail -->
                     <div ng-if="vm.activity.detail" ng-controller="DetailController as detail">

--- a/modules/atlas/components/dashboard/dashboard.html
+++ b/modules/atlas/components/dashboard/dashboard.html
@@ -14,7 +14,7 @@
     <div ng-if="vm.isCatalogus" class="qa-dashboard__catalogus-header c-dashboard__heading">
         <dp-cards-header query="{{vm.dataSelectionState.query}}"></dp-cards-header>
     </div>
-{{vm.visibility.httpStatus}}
+
     <!-- Body -->
     <div class="c-dashboard__body"
         ng-class="{ 'c-dashboard__body--error': vm.visibility.httpStatus }">

--- a/modules/atlas/readme.md
+++ b/modules/atlas/readme.md
@@ -13,7 +13,6 @@
 | pagina               | page                            | yes, see DEFAULT_STATE |
 | detail               | detail.uri                      | no, detail is null     |
 |                      | detail.isLoading                | no, detail is null     |
-| detailInvisble       | detail.isInvisible              | false                  |
 | volledig-detail      | detail.isFullscreen             | false                  |
 | view                 | dataSelection.view              |                        |
 | dataset              | dataSelection.dataset           |                        |
@@ -28,7 +27,6 @@
 | pitch                | straatbeeld.pitch               | no                     |
 | fov                  | straatbeeld.fov                 | no                     |
 | volledig-straatbeeld | straatbeeld.isFullscreen        | no                     |
-| straatbeeldInvisible | straatbeeld.isInvisible         | false                  |
 |                      | straatbeeld.hotspots            | no, []                 |
 |                      | straatbeeld.isLoading           | no                     |
 |                      | straatbeeld.image               | no                     |

--- a/modules/atlas/services/redux/default-state.constant.js
+++ b/modules/atlas/services/redux/default-state.constant.js
@@ -30,6 +30,7 @@
                 display: 'This is the _display variable as available in each endpoint',
                 geometry: null,
                 isLoading: false,
+                isInvisible: false,
                 isFullscreen: false
             }
             */
@@ -53,6 +54,7 @@
                 }],
                 isLoading: false,
                 isInitial: true,
+                isInvisible: false,
                 isFullscreen: true
             },
             */
@@ -71,6 +73,7 @@
                     [52.1, 4.1],
                     [52.2, 4.0]
                 ],
+                isFullscreen: true,
                 isLoading: false
             },
             */

--- a/modules/atlas/services/redux/default-state.constant.js
+++ b/modules/atlas/services/redux/default-state.constant.js
@@ -30,7 +30,6 @@
                 display: 'This is the _display variable as available in each endpoint',
                 geometry: null,
                 isLoading: false,
-                isInvisible: false,
                 isFullscreen: false
             }
             */
@@ -54,7 +53,6 @@
                 }],
                 isLoading: false,
                 isInitial: true,
-                isInvisible: false,
                 isFullscreen: true
             },
             */

--- a/modules/atlas/services/redux/reducers/data-selection-reducers.factory.js
+++ b/modules/atlas/services/redux/reducers/data-selection-reducers.factory.js
@@ -50,6 +50,7 @@
                 // Default view is table view
                 newState.dataSelection.view = 'TABLE';
             }
+
             // LIST loading might include markers => set map loading accordingly
             newState.map.isLoading = newState.dataSelection.view === 'LIST';
 
@@ -72,8 +73,8 @@
             if (newState.dataSelection) {
                 newState.dataSelection.markers = payload;
                 newState.dataSelection.isLoading = false;
-                // Set map loading if any markers need to be shown
-                newState.map.isLoading = newState.dataSelection.markers.length > 0;
+
+                newState.map.isLoading = false;
                 newState.dataSelection.isFullscreen = newState.dataSelection.view !== 'LIST';
             }
 

--- a/modules/atlas/services/redux/reducers/data-selection-reducers.factory.test.js
+++ b/modules/atlas/services/redux/reducers/data-selection-reducers.factory.test.js
@@ -213,14 +213,6 @@ describe('The dataSelectionReducers factory', function () {
             expect(output.dataSelection.isLoading).toEqual(false);
         });
 
-        it('sets map.isLoading to true when any markers are added to the state', function () {
-            output = dataSelectionReducers[ACTIONS.SHOW_DATA_SELECTION.id](mockedState, payload);
-            expect(output.map.isLoading).toBe(true);
-
-            output = dataSelectionReducers[ACTIONS.SHOW_DATA_SELECTION.id](mockedState, []);
-            expect(output.map.isLoading).toBe(false);
-        });
-
         it('does nothing if the user has navigated away from dataSelection before the API is finished', function () {
             mockedState.dataSelection = null;
             output = dataSelectionReducers[ACTIONS.SHOW_DATA_SELECTION.id](mockedState, payload);

--- a/modules/atlas/services/redux/reducers/detail-reducers.factory.js
+++ b/modules/atlas/services/redux/reducers/detail-reducers.factory.js
@@ -54,8 +54,6 @@
 
             // Detail can be null if another action gets triggered between FETCH_DETAIL and SHOW_DETAIL
             if (angular.isObject(newState.detail)) {
-                newState.detail.isInvisible = false;
-
                 newState.detail.display = payload.display;
                 newState.detail.geometry = payload.geometry;
                 newState.detail.isFullscreen = payload.isFullscreen;

--- a/modules/atlas/services/redux/reducers/map-reducers.factory.js
+++ b/modules/atlas/services/redux/reducers/map-reducers.factory.js
@@ -136,18 +136,6 @@
             if (payload) {
                 // Set map to full screen
                 newState.layerSelection = false;
-                if (angular.isObject(newState.straatbeeld)) {
-                    // If the map is maximized when a straatbeeld is active
-                    // then inactivate straatbeeld
-                    newState.straatbeeld.isInvisible = true;
-                }
-            } else {
-                // Set map back to column view
-                if (angular.isObject(newState.straatbeeld)) {
-                    // If the map is minimized when a straatbeeld is inactive
-                    // then reactivate straatbeeld
-                    newState.straatbeeld.isInvisible = false;
-                }
             }
 
             newState.map.isFullscreen = payload;

--- a/modules/atlas/services/redux/reducers/map-reducers.factory.test.js
+++ b/modules/atlas/services/redux/reducers/map-reducers.factory.test.js
@@ -221,31 +221,6 @@ describe('The map reducers', function () {
             output = mapReducers[ACTIONS.MAP_FULLSCREEN.id](inputState, true);
             expect(output.layerSelection).toBe(false);
         });
-
-        it('when straatbeeld exists, reactivates it on minimize', function () {
-            var inputState = angular.copy(DEFAULT_STATE),
-                output;
-
-            inputState.straatbeeld = {
-                id: 'abc',
-                isInvisible: true
-            };
-
-            output = mapReducers[ACTIONS.MAP_FULLSCREEN.id](inputState, false);
-            expect(output.straatbeeld.isInvisible).toBe(false);
-        });
-
-        it('when straatbeeld exists, hide it on maximize', function () {
-            var inputState = angular.copy(DEFAULT_STATE),
-                output;
-
-            inputState.straatbeeld = {
-                id: 'abc'
-            };
-
-            output = mapReducers[ACTIONS.MAP_FULLSCREEN.id](inputState, true);
-            expect(output.straatbeeld.isInvisible).toBe(true);
-        });
     });
 
     describe('SHOW_MAP_ACTIVE_OVERLAYS', function () {

--- a/modules/atlas/services/redux/reducers/straatbeeld-reducers.factory.js
+++ b/modules/atlas/services/redux/reducers/straatbeeld-reducers.factory.js
@@ -43,13 +43,6 @@
                 newState.straatbeeld.isFullscreen = payload.isFullscreen;
             }
 
-            // If a straatbeeld is loaded by it's id
-            // and detail is active
-            // then inactivate detail
-            if (angular.isObject(newState.detail)) {
-                newState.detail.isInvisible = true;
-            }
-
             newState.map.highlight = null;
 
             newState.search = null;
@@ -100,8 +93,6 @@
         function initializeStraatbeeld (straatbeeld) {
             // Resets straatbeeld properties
             // Leave any other properties of straatbeeld untouched
-            straatbeeld.isInvisible = false;
-
             straatbeeld.id = null;
             straatbeeld.location = null;
 
@@ -140,8 +131,6 @@
 
             // Straatbeeld can be null if another action gets triggered between FETCH_STRAATBEELD and SHOW_STRAATBEELD
             if (angular.isObject(newState.straatbeeld)) {
-                newState.straatbeeld.isInvisible = false;
-
                 newState.straatbeeld.id = payload.id || newState.straatbeeld.id;
                 newState.straatbeeld.date = payload.date;
 

--- a/modules/atlas/services/redux/reducers/straatbeeld-reducers.factory.test.js
+++ b/modules/atlas/services/redux/reducers/straatbeeld-reducers.factory.test.js
@@ -85,29 +85,6 @@ describe('Straatbeeld reducers factory', function () {
             expect(newState.straatbeeld.image).toBeNull();
         });
 
-        it('keeps detail information when starting straatbeeld', function () {
-            inputState.detail = {
-                endpoint: 'bag/verblijfsobject/123/',
-                geometry: 'aap',
-                isLoading: false
-            };
-
-            var newState = straatbeeldReducers[ACTIONS.FETCH_STRAATBEELD.id](inputState, payload);
-            expect(newState.detail.isInvisible).toBe(true);
-        });
-
-        it('resets its invisibility when starting straatbeeld', function () {
-            inputState.detail = {
-                endpoint: 'bag/verblijfsobject/123/',
-                geometry: 'aap',
-                isLoading: false,
-                isInvisible: true
-            };
-
-            var newState = straatbeeldReducers[ACTIONS.FETCH_STRAATBEELD.id](inputState, payload);
-            expect(newState.straatbeeld.isInvisible).toBe(false);
-        });
-
         it('resets search results', function () {
             inputState.search = {
                 query: 'linnaeus'
@@ -132,8 +109,7 @@ describe('Straatbeeld reducers factory', function () {
             inputState.detail = {
                 endpoint: 'bag/verblijfsobject/123/',
                 geometry: 'aap',
-                isLoading: false,
-                isInvisible: true
+                isLoading: false
             };
 
             let newState = straatbeeldReducers[ACTIONS.FETCH_STRAATBEELD.id](inputState, payload);
@@ -256,18 +232,6 @@ describe('Straatbeeld reducers factory', function () {
             expect(output.straatbeeld.targetLocation).toEqual(location);
         });
 
-        it('resets its invibility when fetching straatbeeld', function () {
-            inputState.detail = {
-                endpoint: 'bag/verblijfsobject/123/',
-                geometry: 'aap',
-                isLoading: false,
-                isInvisible: true
-            };
-
-            var newState = straatbeeldReducers[ACTIONS.FETCH_STRAATBEELD_BY_LOCATION.id](inputState, payload);
-            expect(newState.straatbeeld.isInvisible).toBe(false);
-        });
-
         it('centers the map when layerselection or fullscreen map is active', function () {
             let state = {
                 'map': {
@@ -355,12 +319,6 @@ describe('Straatbeeld reducers factory', function () {
             var newState = straatbeeldReducers[ACTIONS.SHOW_STRAATBEELD_INITIAL.id](inputState, payload);
             expect(newState.straatbeeld.isLoading).toBe(false);
             expect(newState.map.isLoading).toBe(false);
-        });
-
-        it('resets its invibility when showing straatbeeld', function () {
-            inputState.straatbeeld.isInvisible = true;
-            var newState = straatbeeldReducers[ACTIONS.SHOW_STRAATBEELD_INITIAL.id](inputState, payload);
-            expect(newState.straatbeeld.isInvisible).toBe(false);
         });
 
         it('does nothing when straatbeeld is null', function () {

--- a/modules/atlas/services/redux/reducers/url-reducers.factory.js
+++ b/modules/atlas/services/redux/reducers/url-reducers.factory.js
@@ -123,9 +123,6 @@
                     newDetailState.isFullscreen = angular.isString(payload['volledig-detail']);
                 }
 
-                // restore invisibility from url payload
-                newDetailState.isInvisible = Boolean(payload.detailInvisible);
-
                 return newDetailState;
             } else {
                 return null;
@@ -143,8 +140,6 @@
                     heading: Number(payload.heading)
                 };
 
-                // restore invisibility from url payload
-                newStraatbeeld.isInvisible = Boolean(payload.straatbeeldInvisible);
                 newStraatbeeld.isFullscreen = angular.isString(payload['volledig-straatbeeld']);
 
                 if (oldState.straatbeeld && oldState.straatbeeld.id === payload.id) {

--- a/modules/atlas/services/redux/reducers/url-reducers.factory.test.js
+++ b/modules/atlas/services/redux/reducers/url-reducers.factory.test.js
@@ -305,27 +305,6 @@ describe('The urlReducers factory', function () {
                 expect(output.detail.endpoint).toBe('https://api.datapunt.amsterdam.nl/bag/verblijfsobject/123/');
             });
 
-            it('can restore its invisibility', function () {
-                let output;
-
-                mockedSearchParams.detail = 'ABC';
-                mockedSearchParams.detailInvisible = true;
-
-                output = urlReducers.URL_CHANGE(mockedState, mockedSearchParams);
-
-                expect(output.detail.isInvisible).toBe(true);
-            });
-
-            it('can restore its invisibility status when not invisible', function () {
-                let output;
-
-                mockedSearchParams.detail = 'ABC';
-
-                output = urlReducers.URL_CHANGE(mockedState, mockedSearchParams);
-
-                expect(output.detail.isInvisible).toBe(false);
-            });
-
             it('remembers the display and geometry of the previous state if the endpoint stays the same', function () {
                 var output;
 
@@ -471,27 +450,6 @@ describe('The urlReducers factory', function () {
                 expect(output.straatbeeld.hotspots).toEqual([]);
                 expect(output.straatbeeld.isLoading).toBe(true);
                 expect(output.straatbeeld.isInitial).toBe(true);
-            });
-
-            it('can restore its invisibility', function () {
-                let output;
-
-                mockedSearchParams.id = 'ABC';
-                mockedSearchParams.straatbeeldInvisible = true;
-
-                output = urlReducers.URL_CHANGE(mockedState, mockedSearchParams);
-
-                expect(output.straatbeeld.isInvisible).toBe(true);
-            });
-
-            it('can restore its invisibility status when not invisible', function () {
-                let output;
-
-                mockedSearchParams.id = 'ABC';
-
-                output = urlReducers.URL_CHANGE(mockedState, mockedSearchParams);
-
-                expect(output.straatbeeld.isInvisible).toBe(false);
             });
 
             it('can restore its location', function () {

--- a/modules/atlas/services/routing/state-to-url.factory.js
+++ b/modules/atlas/services/routing/state-to-url.factory.js
@@ -116,9 +116,6 @@
 
             if (state.detail) {
                 params.detail = state.detail.endpoint || null;
-                if (state.detail.isInvisible) {
-                    params.detailInvisible = true;  // Only store in url on truthy value
-                }
 
                 params['volledig-detail'] = state.detail.isFullscreen ? 'aan' : null;
             }
@@ -134,9 +131,7 @@
                 if (angular.isArray(state.straatbeeld.location)) {
                     params.straatbeeld = state.straatbeeld.location.join(',');
                 }
-                if (state.straatbeeld.isInvisible) {
-                    params.straatbeeldInvisible = true;  // Only store in url on truthy value
-                }
+
                 params.heading = String(state.straatbeeld.heading);
                 params.pitch = String(state.straatbeeld.pitch);
                 params.fov = String(state.straatbeeld.fov);

--- a/modules/atlas/services/routing/state-to-url.factory.js
+++ b/modules/atlas/services/routing/state-to-url.factory.js
@@ -115,7 +115,7 @@
             var params = {};
 
             if (state.detail) {
-                params.detail = state.detail.endpoint || null;
+                params.detail = state.detail.endpoint;
 
                 params['volledig-detail'] = state.detail.isFullscreen ? 'aan' : null;
             }

--- a/modules/atlas/services/routing/state-to-url.factory.test.js
+++ b/modules/atlas/services/routing/state-to-url.factory.test.js
@@ -244,20 +244,6 @@ describe('The stateToUrl factory', function () {
             }));
         });
 
-        it('can set the invisibility of the detail', function () {
-            mockedState.detail = {
-                endpoint: 'ABC',
-                isInvisible: true
-            };
-
-            stateToUrl.update(mockedState, false);
-
-            expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
-                detail: 'ABC',
-                detailInvisible: true
-            }));
-        });
-
         it('can set the fullscreen of detail', function () {
             mockedState.detail = {
                 endpoint: 'ABC',
@@ -269,34 +255,6 @@ describe('The stateToUrl factory', function () {
             expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
                 detail: 'ABC',
                 'volledig-detail': 'aan'
-            }));
-        });
-
-        it('can unset the invisibility of the detail', function () {
-            mockedState.detail = {
-                endpoint: 'ABC',
-                isInvisible: false
-            };
-
-            stateToUrl.update(mockedState, false);
-
-            expect($location.search).not.toHaveBeenCalledWith(jasmine.objectContaining({
-                detailInvisible: true
-            }));
-            expect($location.search).not.toHaveBeenCalledWith(jasmine.objectContaining({
-                detailInvisible: false
-            }));
-        });
-
-        it('can set the invisibility of the detail, even without endpoint', function () {
-            mockedState.detail = {
-                isInvisible: true
-            };
-
-            stateToUrl.update(mockedState, false);
-
-            expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
-                detailInvisible: true
             }));
         });
     });
@@ -362,36 +320,6 @@ describe('The stateToUrl factory', function () {
                 heading: '270',
                 pitch: '10.4',
                 fov: '20'
-            }));
-        });
-
-        it('can set the straatbeeld invisibility', function () {
-            mockedState.straatbeeld = {
-                id: 'ABC',
-                isInvisible: true
-            };
-
-            stateToUrl.update(mockedState, false);
-
-            expect($location.search).toHaveBeenCalledWith(jasmine.objectContaining({
-                id: 'ABC',
-                straatbeeldInvisible: true
-            }));
-        });
-
-        it('can unset the straatbeeld invisibility', function () {
-            mockedState.straatbeeld = {
-                id: 'ABC',
-                isInvisible: false
-            };
-
-            stateToUrl.update(mockedState, false);
-
-            expect($location.search).not.toHaveBeenCalledWith(jasmine.objectContaining({
-                straatbeeldInvisible: false
-            }));
-            expect($location.search).not.toHaveBeenCalledWith(jasmine.objectContaining({
-                straatbeeldInvisible: true
             }));
         });
 

--- a/modules/data-selection/components/data-selection/data-selection.html
+++ b/modules/data-selection/components/data-selection/data-selection.html
@@ -23,7 +23,7 @@
             'u-col-sm--12': !vm.showFilters,
             'u-col-sm--9': vm.showFilters}">
 
-            <dp-loading-indicator is-loading="vm.isLoading" use-delay="true" show-inline="true"></dp-loading-indicator>
+            <dp-loading-indicator is-loading="vm.isLoading" use-delay="false" show-inline="true"></dp-loading-indicator>
 
             <div ng-if="!vm.isLoading">
                 <dp-data-selection-header

--- a/modules/map/components/map/map.directive.js
+++ b/modules/map/components/map/map.directive.js
@@ -102,10 +102,7 @@
 
                 scope.$watch('markers.clustered', function (newCollection, oldCollection) {
                     if (newCollection.length) {
-                        // Showing markers can take some time, set loading indicator
-                        scope.mapState.isLoading = true;
-                        let endLoading = () => scope.$applyAsync(() => scope.mapState.isLoading = false);
-                        highlight.setCluster(leafletMap, newCollection, endLoading);
+                        highlight.setCluster(leafletMap, newCollection);
                     } else {
                         highlight.clearCluster(leafletMap);
                     }

--- a/modules/map/components/map/map.directive.test.js
+++ b/modules/map/components/map/map.directive.test.js
@@ -29,9 +29,7 @@ describe('The dp-map directive', function () {
                     initialize: angular.noop,
                     addMarker: angular.noop,
                     removeMarker: angular.noop,
-                    setCluster: function (map, collection, endLoading) {
-                        endLoading();
-                    },
+                    setCluster: angular.noop,
                     clearCluster: angular.noop
                 },
                 panning: {
@@ -372,11 +370,11 @@ describe('The dp-map directive', function () {
                     [
                         [52.1, 4.1],
                         [52.2, 4.1]
-                    ], jasmine.any(Function)
+                    ]
                 );
             });
 
-            it('can add a group of clustered markers, accepting a method to end the loading indicator', function () {
+            it('can add a group of clustered markers', function () {
                 // Start without any clustered markers
                 let highlightItems = {
                     regular: [],
@@ -396,10 +394,8 @@ describe('The dp-map directive', function () {
                     [
                         [52.1, 4.1],
                         [52.2, 4.1]
-                    ], jasmine.any(Function)
+                    ]
                 );
-                $rootScope.$apply();
-                expect(directive.isolateScope().mapState.isLoading).toBe(false);
             });
 
             it('can remove a group of clustered markers', function () {

--- a/modules/map/services/highlight/highlight.factory.js
+++ b/modules/map/services/highlight/highlight.factory.js
@@ -92,7 +92,7 @@
             leafletMap.removeLayer(layers[item.id]);
         }
 
-        function setCluster (leafletMap, markers, onReady) {
+        function setCluster (leafletMap, markers) {
             clusteredLayer = L.markerClusterGroup(clusteredMarkersConfig);
 
             markers.forEach(marker => {
@@ -102,16 +102,6 @@
                     })
                 );
             });
-
-            let onLayerAdd = (event) => {
-                if (event.layer === clusteredLayer) {
-                    leafletMap.off('layeradd', onLayerAdd);
-                    if (angular.isFunction(onReady)) {
-                        onReady();
-                    }
-                }
-            };
-            leafletMap.on('layeradd', onLayerAdd);
 
             zoomToLayer(leafletMap, clusteredLayer);
             leafletMap.addLayer(clusteredLayer);

--- a/modules/map/services/highlight/highlight.factory.test.js
+++ b/modules/map/services/highlight/highlight.factory.test.js
@@ -339,60 +339,6 @@ describe('The highlight factory', function () {
         expect(mockedLeafletMap.addLayer).toHaveBeenCalledWith(mockedClusteredLayer);
     });
 
-    it('can add clustered markers to the map and invokes callback method when the cluster is loaded', function () {
-        let isLoaded;
-
-        spyOn(mockedLeafletMap, 'off');
-
-        // Simulate that the layer has been succesfully loaded
-        let layerIsLoaded = (event, onEvent) => {
-            onEvent({
-                layer: mockedClusteredLayer
-            });
-        };
-        mockedLeafletMap.on = layerIsLoaded;
-
-        isLoaded = false;
-        highlight.setCluster(mockedLeafletMap, [
-            [52.1, 4.0],
-            [52.2, 4.0],
-            [52.3, 4.1]
-        ], () => isLoaded = true);
-
-        expect(isLoaded).toBe(true);
-        // Check that the event subscription has been cancelled
-        expect(mockedLeafletMap.off).toHaveBeenCalledWith('layeradd', jasmine.any(Function));
-
-        // It should not fail, but only unsubscribe when no function is specified
-        mockedLeafletMap.off.calls.reset();
-        highlight.setCluster(mockedLeafletMap, [
-            [52.1, 4.0],
-            [52.2, 4.0],
-            [52.3, 4.1]
-        ]);
-        expect(mockedLeafletMap.off).toHaveBeenCalledWith('layeradd', jasmine.any(Function));
-
-        mockedLeafletMap.off.calls.reset();
-
-        // Simulate that the layer has not been succesfully loaded
-        let layerIsNotLoaded = (event, onEvent) => {
-            onEvent({
-                layer: 1    // something unequal to the mocked clustered layer
-            });
-        };
-        mockedLeafletMap.on = layerIsNotLoaded;
-
-        isLoaded = false;
-        highlight.setCluster(mockedLeafletMap, [
-            [52.1, 4.0],
-            [52.2, 4.0],
-            [52.3, 4.1]
-        ], () => isLoaded = true);
-
-        expect(isLoaded).toBe(false);
-        expect(mockedLeafletMap.off).not.toHaveBeenCalled();
-    });
-
     it('pans and zooms to the clustered markers after adding them to the map', function () {
         spyOn(mockedLeafletMap, 'getZoom').and.returnValue(13);
 

--- a/modules/shared/components/link/link.component.js
+++ b/modules/shared/components/link/link.component.js
@@ -26,6 +26,13 @@
 
         if (vm.tagName === 'a') {
             vm.href = getHref(vm.type, vm.payload);
+
+            // The href attribute is ignored when left-clicking, it's only a fallback for middle and right mouse button
+            vm.followLink = function (event) {
+                event.preventDefault();
+
+                vm.dispatch();
+            };
         }
 
         vm.dispatch = function () {

--- a/modules/shared/components/link/link.component.test.js
+++ b/modules/shared/components/link/link.component.test.js
@@ -208,14 +208,6 @@ describe('The dp-link component', function () {
         let component = getComponent(null, null, 'ACTION_WITH_LINK', mockedPayload);
 
         expect(component.find('a').attr('href')).toBe(mockedTargetPath);
-    });
-
-    it('clicking the link will follow the href, it won\'t trigger a store.dispatch', function () {
-        let component;
-
-        component = getComponent(null, null, 'ACTION_WITH_LINK', mockedPayload);
-        component.find('a').click();
-        expect(store.dispatch).not.toHaveBeenCalled();
 
         // The value for the href attribute is composed by several injected dependencies, making sure these are used
         expect(mockedReducer).toHaveBeenCalledWith(
@@ -226,6 +218,30 @@ describe('The dp-link component', function () {
             }
         );
         expect(mockedStateToUrl.create).toHaveBeenCalledWith(mockedTargetState);
+    });
+
+    it('left clicking the link will NOT follow the href, it will trigger a regular store.dispatch', function () {
+        let component,
+            mockedClickEvent;
+
+        mockedClickEvent = jasmine.createSpyObj('e', ['preventDefault']);
+
+        component = getComponent(null, null, 'ACTION_WITH_LINK', mockedPayload);
+
+        // Testing $event.preventDefault
+        component.isolateScope().vm.followLink(mockedClickEvent);
+        expect(mockedClickEvent.preventDefault).toHaveBeenCalled();
+
+        // Testing the dispatch
+        component.find('a').click();
+        $rootScope.$apply();
+
+        expect(mockedClickEvent.preventDefault).toHaveBeenCalled();
+
+        expect(store.dispatch).toHaveBeenCalledWith({
+            type: mockedActions.ACTION_WITH_LINK,
+            payload: mockedPayload
+        });
     });
 
     it('transcludes content without adding whitespace', function () {

--- a/modules/shared/components/link/link.html
+++ b/modules/shared/components/link/link.html
@@ -1,3 +1,3 @@
 <button ng-if="vm.tagName === 'button'" ng-click="vm.dispatch()" class="{{vm.className}}" title="{{vm.hoverText}}"><ng-transclude></ng-transclude></button>
 
-<a ng-if="vm.tagName === 'a'" ng-href="{{vm.href}}" class="{{vm.className}}" title="{{vm.hoverText}}"><ng-transclude></ng-transclude></a>
+<a ng-if="vm.tagName === 'a'" ng-href="{{vm.href}}" class="{{vm.className}}" title="{{vm.hoverText}}" ng-click="vm.followLink($event)"><ng-transclude></ng-transclude></a>


### PR DESCRIPTION
**Dashboard**
Het dashboard maakt nu onderscheid tussen actief (inladen via ng-if) en visible tonen via (ng-show).

Dit lost 2 problemen op: een kaart met volledig scherm en geometrie van een detailpagina of een puntenwolk van data selectie blijft nu behouden na een pagina refresh.

Plus:
- columnSizes is weer leading. Als je iets fullscreen wilt dan zet je gewoon de columnSize op 12.
- dp-straatbeeld wordt niet langer op twee plekken ingeladen
- Heel veel business logica uit de HTML gesloopt



**Puntenwolk en loading indicator op de kaart**
De map directive ging lokaal de applicatie state overschrijven. Dit heb ik teruggedraaid.

Nadeel: de loading indicator verdwijnt nu als de API call klaar is, daarna moet de Leaflet cluster plugin alles nog renderen. De loading indicator verdwijnt soms iets te vroeg.

**dp-link**
In de lijstweergave bij data selectie wordt de map gecentreerd en gezoomed naar de default waardes. Alle paginatie links verwijzen hierdoor altijd naar deze default locatie. Dit is niet wenselijk. We willen namelijk niet de kaart zien verspringen terwijl de markers gewoon gelijk blijven. (De markers zijn niet afhankelijk van de huidige pagina).

Oplossing: Klikken met de linkermuisknop op een dp-link met `<a>` triggered gewoon een store.dispatch. Alleen links openen in een nieuw tabblad maakt gebruik van het href attribuut.