### PR TITLE
[tg-2123] nevenadressen bij pand en kot

### DIFF
--- a/modules/detail/components/detail/templates/bag/pand.html
+++ b/modules/detail/components/detail/templates/bag/pand.html
@@ -35,9 +35,19 @@
     </div>
 
     <div ng-if="vm.apiData.results.verblijfsobjecten.count">
+        <!--
+        There is no _adressen.count variable. But this check is still valid, because:
+
+        - A pand has 0-n verblijfsobjecten
+        - A verblijfsobject has 1-n adressen
+        - An adres is always related to a verblijfsobject
+
+        So; there are no adressen if there are no verblijfsobjecten. And if there are any verblijfsobjecten there must
+        be at least one adres for each verblijfsobject as well.
+        -->
         <dp-stelselpedia-header definition="NUMMERAANDUIDING" use-plural="true"></dp-stelselpedia-header>
 
-        <dp-api-call endpoint="{{vm.apiData.results.verblijfsobjecten.href}}" partial="adressen_lijst"></dp-api-call>
+        <dp-api-call endpoint="{{vm.apiData.results._adressen.href}}" partial="adressen_lijst"></dp-api-call>
     </div>
 
     <div>

--- a/modules/detail/components/detail/templates/brk/object.html
+++ b/modules/detail/components/detail/templates/brk/object.html
@@ -1,4 +1,5 @@
 <div>
+    BEN IK HIER?
     <div class="u-row">
         <dp-stelselpedia-header
             heading="{{vm.apiData.results._display}}"
@@ -47,9 +48,19 @@
     </dp-api-call>
 
     <div ng-if="vm.apiData.results.verblijfsobjecten.count">
+        <!--
+        There is no _adressen.count variable. But this check is still valid, because:
+
+        - A pand has 0-n verblijfsobjecten
+        - A verblijfsobject has 1-n adressen
+        - An adres is always related to a verblijfsobject
+
+        So; there are no adressen if there are no verblijfsobjecten. And if there are any verblijfsobjecten there must
+        be at least one adres for each verblijfsobject as well.
+        -->
         <dp-stelselpedia-header definition="NUMMERAANDUIDING" use-plural="true"></dp-stelselpedia-header>
 
-        <dp-api-call endpoint="{{vm.apiData.results.verblijfsobjecten.href}}" partial="adressen_lijst">
+        <dp-api-call endpoint="{{vm.apiData.results._adressen.href}}" partial="adressen_lijst">
         </dp-api-call>
     </div>
 </div>

--- a/modules/detail/components/detail/templates/brk/object.html
+++ b/modules/detail/components/detail/templates/brk/object.html
@@ -1,5 +1,4 @@
 <div>
-    BEN IK HIER?
     <div class="u-row">
         <dp-stelselpedia-header
             heading="{{vm.apiData.results._display}}"

--- a/modules/search-results/services/geosearch/geosearch.factory.js
+++ b/modules/search-results/services/geosearch/geosearch.factory.js
@@ -53,7 +53,7 @@
                 const vestigingenUri = `handelsregister/vestiging/?pand=${pand.pandidentificatie}`;
 
                 $q.all([
-                    api.getByUrl(pand.verblijfsobjecten.href).then(formatVerblijfsobjecten),
+                    api.getByUrl(pand._adressen.href).then(formatVerblijfsobjecten),
                     api.getByUri(vestigingenUri).then(formatVestigingen)
                 ]).then(combineResults);
 

--- a/modules/search-results/services/geosearch/geosearch.factory.test.js
+++ b/modules/search-results/services/geosearch/geosearch.factory.test.js
@@ -15,8 +15,8 @@ describe('The geosearch factory', function () {
         mockedFormattedStandplaatsSearchResult,
         mockedPandApiResults,
         mockedStandplaatsApiResults,
-        mockedVerblijfsobjectenApiResults,
-        mockedFormattedVerblijfsobjectenApiResults,
+        mockedNummeraanduidingApiResults,
+        mockedFormattedNummeraanduidingenApiResults,
         mockedVestigingenApiResults,
         mockedFormattedVestigingenApiResults;
 
@@ -49,9 +49,9 @@ describe('The geosearch factory', function () {
                             q.resolve(mockedPandApiResults);
                         } else if (endpoint === 'https://api.datapunt.amsterdam.nl/bag/standplaats/0456789/') {
                             q.resolve(mockedStandplaatsApiResults);
-                        } else if (endpoint === 'https://api.datapunt.amsterdam.nl/bag/verblijfsobject/?panden__id=04' +
-                            '56789') {
-                            q.resolve(mockedVerblijfsobjectenApiResults);
+                        } else if (endpoint === 'https://api.datapunt.amsterdam.nl/bag/nummeraanduiding/?pand=0456789'
+                            ) {
+                            q.resolve(mockedNummeraanduidingApiResults);
                         }
 
                         return q.promise;
@@ -60,7 +60,7 @@ describe('The geosearch factory', function () {
                 searchFormatter: {
                     formatCategory: category => {
                         if (category === 'adres') {
-                            return mockedFormattedVerblijfsobjectenApiResults;
+                            return mockedFormattedNummeraanduidingenApiResults;
                         } else if (category === 'vestiging') {
                             return mockedFormattedVestigingenApiResults;
                         }
@@ -215,8 +215,8 @@ describe('The geosearch factory', function () {
                 }
             },
             pandidentificatie: '0456789',
-            verblijfsobjecten: {
-                href: 'https://api.datapunt.amsterdam.nl/bag/verblijfsobject/?panden__id=0456789'
+            _adressen: {
+                href: 'https://api.datapunt.amsterdam.nl/bag/nummeraanduiding/?pand=0456789'
             }
         };
 
@@ -251,12 +251,12 @@ describe('The geosearch factory', function () {
             }
         };
 
-        mockedVerblijfsobjectenApiResults = {
+        mockedNummeraanduidingApiResults = {
             count: 2,
             results: [{xyz: 'FAKE_VBO_RESULT_1'}, {xyz: 'FAKE_VBO_RESULT_2'}]
         };
 
-        mockedFormattedVerblijfsobjectenApiResults = {
+        mockedFormattedNummeraanduidingenApiResults = {
             label_singular: 'Adres',
             label_plural: 'Adressen',
             slug: 'adres',
@@ -368,7 +368,7 @@ describe('The geosearch factory', function () {
             mockedFormattedSearchResults.splice(1, 0, mockedFormattedPandSearchResult);
 
             expectedSearchResults = angular.copy(mockedFormattedSearchResults);
-            expectedSearchResults.splice(2, 0, mockedFormattedVerblijfsobjectenApiResults);
+            expectedSearchResults.splice(2, 0, mockedFormattedNummeraanduidingenApiResults);
 
             geosearch.search([52.789, 4.987]).then(function (_searchResults_) {
                 searchResults = _searchResults_;
@@ -386,9 +386,9 @@ describe('The geosearch factory', function () {
             expect(api.getByUrl)
                 .toHaveBeenCalledWith('https://api.datapunt.amsterdam.nl/bag/pand/0456789/');
             expect(api.getByUrl)
-                .toHaveBeenCalledWith('https://api.datapunt.amsterdam.nl/bag/verblijfsobject/?panden__id=0456789');
+                .toHaveBeenCalledWith('https://api.datapunt.amsterdam.nl/bag/nummeraanduiding/?pand=0456789');
 
-            expect(searchFormatter.formatCategory).toHaveBeenCalledWith('adres', mockedVerblijfsobjectenApiResults);
+            expect(searchFormatter.formatCategory).toHaveBeenCalledWith('adres', mockedNummeraanduidingApiResults);
             expect(searchResults).toEqual(expectedSearchResults);
         });
 
@@ -396,7 +396,7 @@ describe('The geosearch factory', function () {
             var searchResults,
                 expectedSearchResults;
 
-            mockedVerblijfsobjectenApiResults = {
+            mockedNummeraanduidingApiResults = {
                 count: 0,
                 results: []
             };
@@ -440,7 +440,7 @@ describe('The geosearch factory', function () {
 
             expectedSearchResults = angular.copy(mockedFormattedSearchResults);
             expectedSearchResults.splice(2, 0, mockedFormattedVestigingenApiResults);
-            expectedSearchResults.splice(2, 0, mockedFormattedVerblijfsobjectenApiResults);
+            expectedSearchResults.splice(2, 0, mockedFormattedNummeraanduidingenApiResults);
 
             geosearch.search([52.789, 4.987]).then(function (_searchResults_) {
                 searchResults = _searchResults_;
@@ -464,7 +464,7 @@ describe('The geosearch factory', function () {
             expect(api.getByUrl)
                 .toHaveBeenCalledWith('https://api.datapunt.amsterdam.nl/bag/pand/0456789/');
             expect(api.getByUrl)
-                .toHaveBeenCalledWith('https://api.datapunt.amsterdam.nl/bag/verblijfsobject/?panden__id=0456789');
+                .toHaveBeenCalledWith('https://api.datapunt.amsterdam.nl/bag/nummeraanduiding/?pand=0456789');
 
             expect(api.getByUri)
                 .toHaveBeenCalledWith('handelsregister/vestiging/?pand=0456789');
@@ -476,7 +476,7 @@ describe('The geosearch factory', function () {
         it('sometimes has no related verblijfsobjecten nor vestigingen', function () {
             var searchResults;
 
-            mockedVerblijfsobjectenApiResults = {
+            mockedNummeraanduidingApiResults = {
                 count: 0,
                 results: []
             };


### PR DESCRIPTION
Nevenadressen tonen plus de '(nevenadres)' toevoeging bij:

De detailpagina's van:
- bag/pand
- brk/object

De geosearch (klikken op de kaart) zoekresultaten.