### PR TITLE
Bug/tg 2365 pagination centered

### DIFF
--- a/modules/data-selection/components/pagination/_pagination.scss
+++ b/modules/data-selection/components/pagination/_pagination.scss
@@ -72,8 +72,8 @@ $pagination-line-color: #e4e4e4;
 
 .c-data-selection-pagination__go {
   position: absolute;
-  left: 0;
   right: 0;
+  left: 0;
   z-index: 1;
 }
 

--- a/modules/data-selection/components/pagination/_pagination.scss
+++ b/modules/data-selection/components/pagination/_pagination.scss
@@ -21,6 +21,9 @@ $pagination-line-color: #e4e4e4;
 
 .c-data-selection-pagination {
   @include data-selection-pagination-font;
+
+  position: relative;
+  height: $base-whitespace * 4.6;
   padding-bottom: $base-whitespace * 2;
   text-align: center;
 
@@ -59,6 +62,25 @@ $pagination-line-color: #e4e4e4;
   }
   border: none;
   background: $pagination-line-color;
+}
+
+.c-data-selection-pagination__backward {
+  position: absolute;
+  left: 0;
+  z-index: 2;
+}
+
+.c-data-selection-pagination__go {
+  position: absolute;
+  left: 0;
+  right: 0;
+  z-index: 1;
+}
+
+.c-data-selection-pagination__forward {
+  position: absolute;
+  right: 0;
+  z-index: 2;
 }
 
 .c-data-selection-pagination-link {

--- a/modules/data-selection/components/pagination/pagination.html
+++ b/modules/data-selection/components/pagination/pagination.html
@@ -1,11 +1,11 @@
 <div class="c-data-selection-pagination" ng-if="vm.showPagination">
     <div class="c-data-selection-pagination--separator"></div>
 
-    <div class="u-pull--left c-data-selection-page--form-links">
+    <div class="c-data-selection-pagination__backward">
         <dp-data-selection-pagination-link link="vm.firstPage"></dp-data-selection-pagination-link>
         <dp-data-selection-pagination-link link="vm.previousPage"></dp-data-selection-pagination-link>
     </div>
-    <form class="u-inline-block" ng-submit="vm.goToPage($event)">
+    <form class="c-data-selection-pagination__go" ng-submit="vm.goToPage($event)">
         <span class="u-margin__right--1 c-data-selection-pagination-link-text">Naar pagina</span>
         <input ng-model="vm.currentPage" type="number" class="c-data-selection-pagination__input" pattern="\d*" size="4" maxlength="4">
         <button type="submit" class="c-data-selection-pagination__button" title="Ga naar ingevoerde pagina">Ga
@@ -13,7 +13,7 @@
         </button>
         <span class="u-margin__left--1 c-data-selection-pagination-link-text">van {{ vm.numberOfPages }}</span>
     </form>
-    <div class="u-pull--right c-data-selection-page--form-links">
+    <div class="c-data-selection-pagination__forward">
         <dp-data-selection-pagination-link link="vm.nextPage"></dp-data-selection-pagination-link>
         <dp-data-selection-pagination-link link="vm.lastPage"></dp-data-selection-pagination-link>
     </div>

--- a/modules/shared/styles/config/mixins/_icon.scss
+++ b/modules/shared/styles/config/mixins/_icon.scss
@@ -52,6 +52,8 @@
   &::before {
     @extend %#{"dp-" + $icon + if(str-length($state) > 0, "-", "") + $state + "-icon"};
     @extend %icon-button-text-extra;
+
+    margin-right: $base-whitespace / 2;
   }
 
   &:hover,


### PR DESCRIPTION
Go-to-page is nu altijd gecentreerd, ook op pagina één.
Eerste- en vorige-knopjes hebben nu een ruimte tussen icon en label.