### PR TITLE
Feature/bevindingen draw tool

### DIFF
--- a/modules/map/components/map/_map.scss
+++ b/modules/map/components/map/_map.scss
@@ -33,3 +33,13 @@
   border-bottom: none;
   z-index: 3;
 }
+
+.s-leaflet-draw {
+  .leaflet-draw-tooltip {
+    color: $primary-light;
+
+    .leaflet-draw-tooltip-subtext {
+      color: $primary-light;
+    }
+  }
+}

--- a/modules/map/components/map/_map.scss
+++ b/modules/map/components/map/_map.scss
@@ -35,6 +35,7 @@
 }
 
 .s-leaflet-draw {
+  //Override leaflet draw tooltip in draw and edit mode to show text in white
   .leaflet-draw-tooltip {
     color: $primary-light;
 

--- a/modules/map/components/map/map.html
+++ b/modules/map/components/map/map.html
@@ -1,7 +1,7 @@
 <dp-loading-indicator is-loading="mapState.isLoading" use-delay="true" show-inline="false"></dp-loading-indicator>
 
 <div class="c-map">
-    <div class="c-map__leaflet js-leaflet-map"></div>
+    <div class="s-leaflet-draw c-map__leaflet js-leaflet-map"></div>
 
     <div class="c-map__overlay-buttons">
         <dp-toggle-layer-selection

--- a/modules/map/components/toggle-drawing-tool/_toggle-drawing-tool.scss
+++ b/modules/map/components/toggle-drawing-tool/_toggle-drawing-tool.scss
@@ -1,6 +1,8 @@
 .c-toggle-drawing-tool {
   @extend %draw-tool-element;
 
+  border: 0;
+
   &:not(.c-toggle-drawing-tool--active) {
     @include icon-button("polygon-measure");
   }

--- a/modules/map/components/toggle-drawing-tool/_toggle-drawing-tool.scss
+++ b/modules/map/components/toggle-drawing-tool/_toggle-drawing-tool.scss
@@ -1,8 +1,6 @@
 .c-toggle-drawing-tool {
   @extend %draw-tool-element;
 
-  border: 0;
-
   &:not(.c-toggle-drawing-tool--active) {
     @include icon-button("polygon-measure");
   }

--- a/modules/map/components/toggle-drawing-tool/_toggle-drawing-tool.scss
+++ b/modules/map/components/toggle-drawing-tool/_toggle-drawing-tool.scss
@@ -1,6 +1,8 @@
 .c-toggle-drawing-tool {
   @extend %draw-tool-element;
 
+  border: none;
+
   &:not(.c-toggle-drawing-tool--active) {
     @include icon-button("polygon-measure");
   }


### PR DESCRIPTION
- de positie van het teken (icoon) knopje linksbovenin klopt niet. Deze zou op de outline van de kaart moeten staan, zodat de lijn doorloopt. left: -1px; position: absolute; top: -1px;?
- In de tooltip (naast cursor) graag de letter wit zowel in initiele tekenmodus als in edit modus