### PR TITLE
e2e: separate test data from test logic - step 1

### DIFF
--- a/e2e/helpers/available-states.js
+++ b/e2e/helpers/available-states.js
@@ -1,7 +1,13 @@
 module.exports = {
     'DATA-SELECTION--CARDS': {
         url: '#?mpv=52.3719:4.9012&mpb=topografie&mpz=9&dsv=CARDS&dsd=catalogus&dsp=1',
-        validator: require('../validators/states/data-selection--cards')
+        validator: require('../validators/states/data-selection--cards'),
+        expected: {
+            title: 'Dataset Catalogus - Atlas',
+            headerTitle: /datasets/,
+            availableFilterVisible: true,
+            categories0Header: 'Thema\'s'
+        }
     },
     'DATA-SELECTION--TABLE': {
         url: '#?mpv=52.3719:4.9012&mpb=topografie&mpz=9&dsv=TABLE&dsd=bag&dsp=1',

--- a/e2e/helpers/page-check.js
+++ b/e2e/helpers/page-check.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function (actual, expected) {
+    Object.keys(expected).forEach(key => {
+        if (typeof expected[key] === 'object') {    // Regular expression
+            expect(actual[key]).toMatch(expected[key]);
+        } else {                                    // string, number, boolean
+            expect(actual[key]).toBe(expected[key]);
+        }
+    });
+};

--- a/e2e/helpers/page-check.js
+++ b/e2e/helpers/page-check.js
@@ -2,7 +2,7 @@
 
 module.exports = function (actual, expected) {
     Object.keys(expected).forEach(key => {
-        if (typeof expected[key] === 'object') {    // Regular expression
+        if (expected[key] instanceof RegExp) {    // Regular expression
             expect(actual[key]).toMatch(expected[key]);
         } else {                                    // string, number, boolean
             expect(actual[key]).toBe(expected[key]);

--- a/e2e/url-checker.test.js
+++ b/e2e/url-checker.test.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const availableStates = require('./helpers/available-states');
+const validator = require('./validators/validator');
 
 describe('each URL should load the corresponding view', function () {
     Object.keys(availableStates).forEach(key => {
         it(key, () => {
             const page = dp.navigate(key);
 
-            availableStates[key].validator(page);
+            validator(key, page);
         });
     });
 });

--- a/e2e/validators/states/data-selection--cards.js
+++ b/e2e/validators/states/data-selection--cards.js
@@ -1,13 +1,15 @@
 'use strict';
 
 const dataSelectionValidator = require('./data-selection');
+const pageCheck = require('./../../helpers/page-check');
 
-module.exports = function (page) {
-    expect(page.title).toBe('Dataset Catalogus - Atlas');
-
-    expect(page.dashboard.rightColumn.dataSelection.header.title).toContain('datasets');
-    expect(page.dashboard.rightColumn.dataSelection.availableFilters.visible).toBe(true);
-    expect(page.dashboard.rightColumn.dataSelection.availableFilters.categories(0).header).toBe('Thema\'s');
+module.exports = function (page, expected) {
+    pageCheck({
+        title: page.title,
+        headerTitle: page.dashboard.rightColumn.dataSelection.header.title,
+        availableFilterVisible: page.dashboard.rightColumn.dataSelection.availableFilters.visible,
+        categories0Header: page.dashboard.rightColumn.dataSelection.availableFilters.categories(0).header
+    }, expected);
 
     dataSelectionValidator(page);
 };

--- a/e2e/validators/validator.js
+++ b/e2e/validators/validator.js
@@ -1,3 +1,3 @@
-module.exports = function (state, page) {
-    dp.availableStates[state].validator(page);
+module.exports = function (state, page, expected) {
+    dp.availableStates[state].validator(page, expected || dp.availableStates[state].expected);
 };


### PR DESCRIPTION
Deze pull request dient als afstemming concept.
Doel is om de code reviews klein te houden, concepten onderling vroeg in het proces af te stemmen en zo snel mogelijk functioneel te kunnen reviewen (nvt in dit geval) en te mergen met de master branch.
De reden daarvoor is dat reviews van te grote pull requests afbreuk doen aan de kwaliteit van de reviews maar ook mogelijkheden om ontwerpbeslissingen af te stemmen feitelijk onmogelijk maken.

Inhoud:
Add expectation as seperate object which can be overridden in other tests to test partial or different values
PageCheck helper introduced
Implemented first example in DataSelection-cards
Updated validator to allow for different or partial testvalues
Let urlChecker use validator to minimize code duplication