### PR TITLE
Feature/tg2946 zoekgedrag (comments verwerkt in #2947 resultatenheaders)

### DIFF
--- a/modules/atlas/components/dashboard/synchronisation/search-results.controller.js
+++ b/modules/atlas/components/dashboard/synchronisation/search-results.controller.js
@@ -22,6 +22,10 @@
                 vm.location = state.search.location;
                 vm.category = state.search.category;
                 vm.numberOfResults = state.search.numberOfResults;
+
+                if (vm.location === null && vm.query === null) {
+                    vm.query = '';
+                }
             }
         }
     }

--- a/modules/atlas/components/dashboard/synchronisation/search-results.controller.js
+++ b/modules/atlas/components/dashboard/synchronisation/search-results.controller.js
@@ -22,10 +22,6 @@
                 vm.location = state.search.location;
                 vm.category = state.search.category;
                 vm.numberOfResults = state.search.numberOfResults;
-
-                if (vm.location === null && vm.query === null) {
-                    vm.query = '';
-                }
             }
         }
     }

--- a/modules/atlas/services/redux/reducers/search-reducers.factory.js
+++ b/modules/atlas/services/redux/reducers/search-reducers.factory.js
@@ -28,7 +28,8 @@
 
             newState.search = {
                 isLoading: true,
-                query: payload,
+                isEnabled: true,
+                query: payload || null,
                 location: null,
                 category: null,
                 numberOfResults: null
@@ -56,6 +57,7 @@
 
             newState.search = {
                 isLoading: true,
+                isEnabled: true,
                 query: null,
                 location: dpBaseCoder.toPrecision(payload, 7),
                 category: null,

--- a/modules/atlas/services/redux/reducers/search-reducers.factory.test.js
+++ b/modules/atlas/services/redux/reducers/search-reducers.factory.test.js
@@ -58,6 +58,38 @@ describe('The search-reducers factory', function () {
             expect(output.search.numberOfResults).toBeNull();
         });
 
+        it('sets query to null on empty string payload', function () {
+            var inputState = angular.copy(DEFAULT_STATE),
+                output;
+
+            inputState.search = {
+                query: 'xyz',
+                location: [12.345, 6.789],
+                category: 'adres',
+                numberOfResults: 23
+            };
+
+            output = searchReducers[ACTIONS.FETCH_SEARCH_RESULTS_BY_QUERY.id](inputState, '');
+
+            expect(output.search.query).toBe(null);
+        });
+
+        it('sets query isEnabled to true', function () {
+            var inputState = angular.copy(DEFAULT_STATE),
+                output;
+
+            inputState.search = {
+                query: 'xyz',
+                location: [12.345, 6.789],
+                category: 'adres',
+                numberOfResults: 23
+            };
+
+            output = searchReducers[ACTIONS.FETCH_SEARCH_RESULTS_BY_QUERY.id](inputState, '');
+
+            expect(output.search.isEnabled).toBe(true);
+        });
+
         it('hides the layer selection, page, detail, straatbeeld and dataSelection', function () {
             var inputState = angular.copy(DEFAULT_STATE),
                 output;
@@ -141,6 +173,22 @@ describe('The search-reducers factory', function () {
             expect(output.search.location).toEqual([52.001, 4.002]);
             expect(output.search.category).toBeNull();
             expect(output.search.numberOfResults).toBeNull();
+        });
+
+        it('sets query isEnabled to true', function () {
+            var inputState = angular.copy(DEFAULT_STATE),
+                output;
+
+            inputState.search = {
+                query: 'some query',
+                location: null,
+                category: 'adres',
+                numberOfResults: 23
+            };
+
+            output = searchReducers[ACTIONS.FETCH_SEARCH_RESULTS_BY_LOCATION.id](inputState, [52.001, 4.002]);
+
+            expect(output.search.isEnabled).toBe(true);
         });
 
         it('rounds the search location with a precision of 7 decimals', () => {

--- a/modules/atlas/services/routing/state-url-conversion.constant.js
+++ b/modules/atlas/services/routing/state-url-conversion.constant.js
@@ -264,6 +264,10 @@
                     name: 'search.category',
                     type: 'string'
                 },
+                sre: {
+                    name: 'search.isEnabled',
+                    type: 'boolean'
+                },
                 srl: {
                     name: 'search.location',
                     type: 'base62[]',

--- a/modules/data-selection/components/data-selection/data-selection.component.js
+++ b/modules/data-selection/components/data-selection/data-selection.component.js
@@ -35,6 +35,8 @@
         vm.showCatalogusIntroduction = vm.state.view === 'CARDS' &&
             userSettings.showCatalogusIntroduction.value === true.toString();
 
+        vm.showTabHeader = () => Object.keys(vm.state.filters).length === 0;
+
         $scope.$watch('vm.showCatalogusIntroduction', function () {
             userSettings.showCatalogusIntroduction.value = vm.showCatalogusIntroduction.toString();
         });

--- a/modules/data-selection/components/data-selection/data-selection.component.test.js
+++ b/modules/data-selection/components/data-selection/data-selection.component.test.js
@@ -163,6 +163,23 @@ describe('The dp-data-selection component', function () {
         expect(scope.vm.numberOfRecords).toBe(77);
     });
 
+    it('hides the tab header in CARDS view when any filters are active', function () {
+        mockedState.view = 'CARDS';
+        const component = getComponent(mockedState);
+        let scope = component.isolateScope();
+        expect(scope.vm.showTabHeader()).toBe(false);
+        expect(component.find('dp-tab-header').length).toBe(0);
+    });
+
+    it('shows the tab header in CARDS view when no filters are active', function () {
+        mockedState.view = 'CARDS';
+        mockedState.filters = {};
+        const component = getComponent(mockedState);
+        let scope = component.isolateScope();
+        expect(scope.vm.showTabHeader()).toBe(true);
+        expect(component.find('dp-tab-header').length).toBe(1);
+    });
+
     it('either calls the TABLE, LIST or CARDS view', function () {
         let component;
 

--- a/modules/data-selection/components/data-selection/data-selection.html
+++ b/modules/data-selection/components/data-selection/data-selection.html
@@ -19,7 +19,7 @@
         </p>
     </dp-panel>
 
-    <dp-tab-header title="Resultaten met &quot;{{vm.state.query}}&quot;" tab-header="vm.tabHeader"></dp-tab-header>
+    <dp-tab-header search-text="{{vm.state.query}}" tab-header="vm.tabHeader"></dp-tab-header>
 
     <dp-panel is-panel-visible="true">
         <p class="u-margin__bottom--0">

--- a/modules/data-selection/components/data-selection/data-selection.html
+++ b/modules/data-selection/components/data-selection/data-selection.html
@@ -19,7 +19,7 @@
         </p>
     </dp-panel>
 
-    <dp-tab-header search-text="{{vm.state.query}}" tab-header="vm.tabHeader"></dp-tab-header>
+    <dp-tab-header ng-if="vm.showTabHeader()" search-text="{{vm.state.query}}" tab-header="vm.tabHeader"></dp-tab-header>
 
     <dp-panel is-panel-visible="true">
         <p class="u-margin__bottom--0">

--- a/modules/header/components/search/_search.scss
+++ b/modules/header/components/search/_search.scss
@@ -47,3 +47,18 @@ $submit-button-width: 30px;
     background-color: $primary-contrast;
   }
 }
+
+.c-search-form__clear {
+  @include icon-button("close", "transparent", "red");
+
+  width: $submit-button-width;
+  height: $search-form-height;
+  margin-left: -2 * $submit-button-width;
+  float: left;
+  outline: none;
+  cursor: pointer;
+
+  &:hover {
+    background-color: $primary-contrast;
+  }
+}

--- a/modules/header/components/search/search.directive.js
+++ b/modules/header/components/search/search.directive.js
@@ -35,6 +35,12 @@
                 removeSuggestions();
             };
 
+            scope.clear = function () {
+                scope.query = '';
+
+                search();
+            };
+
             scope.getSuggestions = function () {
                 /**
                  * Cancel the last request (if any), this way we ensure that a resolved autocompleteData.search() call

--- a/modules/header/components/search/search.directive.js
+++ b/modules/header/components/search/search.directive.js
@@ -38,7 +38,9 @@
             scope.clear = function () {
                 scope.query = '';
 
-                search();
+                if (scope.searchOnly) {
+                    search();
+                }
             };
 
             scope.getSuggestions = function () {

--- a/modules/header/components/search/search.directive.test.js
+++ b/modules/header/components/search/search.directive.test.js
@@ -148,6 +148,22 @@ describe('The dp-search directive', function () {
         expect(directive.find('.js-search-input')[0].value).toBe('query without suggestions');
     });
 
+    it('provides for a clear button to clear the searchtext', function () {
+        let directive = getDirective('any query');
+        directive.find('.qa-search-form__clear').click();
+        expect(directive.find('.js-search-input')[0].value).toBe('');
+    });
+
+    it('searches on cleared input when searchOnly is set to be true', function () {
+        let directive = getDirective('any query', 'placeholder', 'FETCH_SEARCH_RESULTS_BY_QUERY', true);
+        spyOn(store, 'dispatch');
+        directive.find('.qa-search-form__clear').click();
+        expect(store.dispatch).toHaveBeenCalledWith({
+            type: ACTIONS.FETCH_SEARCH_RESULTS_BY_QUERY,
+            payload: ''
+        });
+    });
+
     it('optionally accepts a payload to include the query', function () {
         let directive = getDirective('q', 'ph', 'FETCH_SEARCH_RESULTS_BY_QUERY', true, '{aap: "noot"}');
 

--- a/modules/header/components/search/search.directive.test.js
+++ b/modules/header/components/search/search.directive.test.js
@@ -164,6 +164,13 @@ describe('The dp-search directive', function () {
         });
     });
 
+    it('does not search on cleared input when searchOnly is set to be false', function () {
+        let directive = getDirective('any query', 'placeholder', 'FETCH_SEARCH_RESULTS_BY_QUERY', false);
+        spyOn(store, 'dispatch');
+        directive.find('.qa-search-form__clear').click();
+        expect(store.dispatch).not.toHaveBeenCalledWith();
+    });
+
     it('optionally accepts a payload to include the query', function () {
         let directive = getDirective('q', 'ph', 'FETCH_SEARCH_RESULTS_BY_QUERY', true, '{aap: "noot"}');
 

--- a/modules/header/components/search/search.html
+++ b/modules/header/components/search/search.html
@@ -17,7 +17,7 @@
             <span class="u-sr-only">Zoeken</span>
         </button>
 
-        <button class="c-search-form__clear" ng-click="clear()" title="Wis zoektekst">
+        <button class="qa-search-form__clear c-search-form__clear" ng-click="clear()" title="Wis zoektekst">
             <span class="u-sr-only">Wis zoektekst</span>
         </button>
 

--- a/modules/header/components/search/search.html
+++ b/modules/header/components/search/search.html
@@ -17,6 +17,10 @@
             <span class="u-sr-only">Zoeken</span>
         </button>
 
+        <button class="c-search-form__clear" ng-click="clear()" title="Wis zoektekst">
+            <span class="u-sr-only">Wis zoektekst</span>
+        </button>
+
         <div ng-if="!searchOnly && numberOfSuggestions" class="c-autocomplete">
             <h3 class="c-autocomplete__tip">Enkele suggesties</h3>
 

--- a/modules/search-results/components/search-results/search-results.component.js
+++ b/modules/search-results/components/search-results/search-results.component.js
@@ -27,8 +27,10 @@
          */
         $scope.$watch('vm.isLoading', () => {
             if (vm.isLoading) {
-                if (!searchByQuery(vm.query, vm.category)) {
-                    searchByLocation(vm.location);
+                // First try to search on location
+                // Test on isArray(location) is more precise than isString(query) because null maps to empty string (@)
+                if (!searchByLocation(vm.location)) {
+                    searchByQuery(vm.query, vm.category);
                 }
             }
         });
@@ -64,7 +66,7 @@
         }
 
         function searchByQuery (query, category) {
-            let isQuery = angular.isString(query) && query.length;
+            let isQuery = angular.isString(query);
             if (isQuery) {
                 if (angular.isString(category) && category.length) {
                     search.search(query, category).then(setSearchResults);

--- a/modules/search-results/components/search-results/search-results.html
+++ b/modules/search-results/components/search-results/search-results.html
@@ -3,7 +3,7 @@
 
     <div ng-if="!vm.isLoading" class="u-row">
 
-        <dp-tab-header ng-if="!vm.location.length" title="Resultaten met &quot;{{vm.query}}&quot;" tab-header="vm.tabHeader"></dp-tab-header>
+        <dp-tab-header ng-if="!vm.location.length" search-text="{{vm.query}}" tab-header="vm.tabHeader"></dp-tab-header>
 
         <div ng-if="vm.numberOfResults" class="qa-search-result">
             <div ng-if="!vm.category">

--- a/modules/shared/components/tab-header/tab-header.component.js
+++ b/modules/shared/components/tab-header/tab-header.component.js
@@ -6,7 +6,7 @@
         .component('dpTabHeader', {
             templateUrl: 'modules/shared/components/tab-header/tab-header.html',
             bindings: {
-                title: '@',
+                searchText: '@',
                 tabHeader: '<'
             },
             controllerAs: 'vm'

--- a/modules/shared/components/tab-header/tab-header.component.test.js
+++ b/modules/shared/components/tab-header/tab-header.component.test.js
@@ -1,12 +1,12 @@
 describe('The tabHeader component', function () {
     let $compile,
         $rootScope,
-        mockedTitle,
+        mockedSearchText,
         mockedActiveItems,
         mockedInactiveItems;
 
     beforeEach(function () {
-        mockedTitle = 'AnyTitle';
+        mockedSearchText = 'AnySearchText';
 
         mockedActiveItems = [1].map(i => getMockedItem(i, {isActive: true, count: i})); // One active tab
 
@@ -37,7 +37,7 @@ describe('The tabHeader component', function () {
             scope;
 
         element = document.createElement('dp-tab-header');
-        element.setAttribute('title', title);
+        element.setAttribute('search-text', title);
         element.setAttribute('tab-header', 'tabHeader');
 
         scope = $rootScope.$new();
@@ -51,14 +51,14 @@ describe('The tabHeader component', function () {
     }
 
     it('accepts a title and an array of tabs', function () {
-        let component = getComponent(mockedTitle, []);
-        expect(component.find('.qa-tab-header__title').text()).toBe(mockedTitle);
+        let component = getComponent(mockedSearchText, []);
+        expect(component.find('.qa-tab-header__title').text()).toBe(`Resultaten met "${mockedSearchText}"`);
         expect(component.find('ul dp-link').length).toBe(0);
         expect(component.find('.qa-tab-header__active').length).toBe(0);
     });
 
     it('shows a link with the title for each non-active tab', function () {
-        let component = getComponent(mockedTitle, mockedInactiveItems);
+        let component = getComponent(mockedSearchText, mockedInactiveItems);
         expect(component.find('ul dp-link').length).toBe(mockedInactiveItems.length);
         mockedInactiveItems.forEach((item, i) => {
             expect(component.find('ul dp-link').eq(i).text().trim())
@@ -70,7 +70,7 @@ describe('The tabHeader component', function () {
     });
 
     it('shows a tab with the title and number of items for the active tab', function () {
-        let component = getComponent(mockedTitle, mockedActiveItems);
+        let component = getComponent(mockedSearchText, mockedActiveItems);
         expect(component.find('ul dp-link').length).toBe(0);
         expect(component.find('.qa-tab-header__active').length).toBe(mockedActiveItems.length);
         mockedActiveItems.forEach((item, i) => {
@@ -80,7 +80,7 @@ describe('The tabHeader component', function () {
     });
 
     it('shows tabs for inactive and active items', function () {
-        let component = getComponent(mockedTitle, mockedActiveItems.concat(mockedInactiveItems));
+        let component = getComponent(mockedSearchText, mockedActiveItems.concat(mockedInactiveItems));
         expect(component.find('ul dp-link').length).toBe(mockedInactiveItems.length);
         expect(component.find('.qa-tab-header__active').length).toBe(mockedActiveItems.length);
     });

--- a/modules/shared/components/tab-header/tab-header.html
+++ b/modules/shared/components/tab-header/tab-header.html
@@ -6,12 +6,12 @@
                      type="{{tab.action}}"
                      payload="tab.payload"
                      class-name="o-tabs__tab o-tabs__tab--link">
-                {{tab.title}} <span ng-if="tab.count !== null">({{tab.count}})</span>
+                {{tab.title}} <span ng-if="tab.count !== null">({{tab.count | number}})</span>
             </dp-link>
 
             <span ng-if="tab.isActive"
                   class="qa-tab-header__active o-tabs__tab o-tabs__tab--active">
-                {{tab.title}} <span ng-if="tab.count !== null">({{tab.count}})</span>
+                {{tab.title}} <span ng-if="tab.count !== null">({{tab.count | number}})</span>
             </span>
         </li>
     </ul>

--- a/modules/shared/components/tab-header/tab-header.html
+++ b/modules/shared/components/tab-header/tab-header.html
@@ -1,5 +1,5 @@
 <div class="o-tabs qa-tabs u-margin__bottom--1-5">
-    <div class="qa-tab-header__title c-tab-header__title">{{vm.title}}</div>
+    <div class="qa-tab-header__title c-tab-header__title">Resultaten met &quot;{{vm.searchText}}&quot;</div>
     <ul>
         <li ng-repeat="tab in vm.tabHeader.tabs" ng-class="{'is-active': tab.isActive}">
             <dp-link ng-if="!tab.isActive"

--- a/modules/shared/components/tab-header/tab-header.html
+++ b/modules/shared/components/tab-header/tab-header.html
@@ -1,4 +1,4 @@
-<div class="o-tabs qa-tabs u-margin__bottom--1-5">
+<div ng-if="vm.searchText.trim()" class="o-tabs qa-tabs u-margin__bottom--1-5">
     <div class="qa-tab-header__title c-tab-header__title">Resultaten met &quot;{{vm.searchText}}&quot;</div>
     <ul>
         <li ng-repeat="tab in vm.tabHeader.tabs" ng-class="{'is-active': tab.isActive}">


### PR DESCRIPTION
Voor new design branch:
* Is er op tekst gezocht, dan toon 2 tabs: Data en Datasets, anders niet
Uitzondering i.g.v. datasets: is er (na zoeken) gefilterd is (bijv op een thema), dan weergave zonder tabs.
* is er onverhoopt toch gezocht op "" of andere whitespace, dan deze zoekvraag verwijderen en doen alsof er niet gezocht is, maar naar de ongefilterde lijst gebrowsed.
Uitzondering i.g.v. data: niet zoeken op lege zoektekst want daar levert het back-end geen juist resultaat
* Toevoegen kruisje bij zoekknop, om de zoekinvoer te wissen