### PR TITLE
Feature/new design isLoading cleanup

### DIFF
--- a/modules/data-selection/components/available-filters/available-filters.component.js
+++ b/modules/data-selection/components/available-filters/available-filters.component.js
@@ -7,8 +7,7 @@
             bindings: {
                 dataset: '@',
                 availableFilters: '=',
-                activeFilters: '=',
-                isLoading: '='
+                activeFilters: '='
             },
             templateUrl: 'modules/data-selection/components/available-filters/available-filters.html',
             controller: DpDataSelectionAvailableFiltersController,

--- a/modules/data-selection/components/available-filters/available-filters.component.test.js
+++ b/modules/data-selection/components/available-filters/available-filters.component.test.js
@@ -110,7 +110,7 @@ describe('The dp-data-selection-available-filters component', function () {
         spyOn(store, 'dispatch');
     });
 
-    function getComponent (activeFilters, isLoading) {
+    function getComponent (activeFilters) {
         var component,
             element,
             scope;
@@ -120,12 +120,10 @@ describe('The dp-data-selection-available-filters component', function () {
         element.setAttribute('dataset', 'my_special_dataset');
         element.setAttribute('available-filters', 'availableFilters');
         element.setAttribute('active-filters', 'activeFilters');
-        element.setAttribute('is-loading', 'isLoading');
 
         scope = $rootScope.$new();
         scope.availableFilters = availableFilters;
         scope.activeFilters = activeFilters;
-        scope.isLoading = isLoading;
 
         component = $compile(element)(scope);
         scope.$apply();

--- a/modules/data-selection/components/available-filters/available-filters.html
+++ b/modules/data-selection/components/available-filters/available-filters.html
@@ -1,8 +1,6 @@
 <div class="c-data-selection-available-filters">
-    <dp-loading-indicator is-loading="vm.isLoading" use-delay="true" show-inline="true"></dp-loading-indicator>
-
     <div class="qa-available-filters c-data-selection-available-filters--available-filters">
-        <div ng-if="!vm.isLoading" ng-show="vm.hasInactiveFilterOptions(filter)" ng-repeat="filter in vm.availableFilters">
+        <div ng-show="vm.hasInactiveFilterOptions(filter)" ng-repeat="filter in vm.availableFilters">
             <div class="c-data-selection-available-filters__available-filter">
                 <h2 class="c-data-selection-available-filters__available-filter-label qa-category-header">{{filter.label}}</h2>
                 <ul class="c-data-selection-available-filters__list">

--- a/modules/data-selection/components/data-selection/data-selection.html
+++ b/modules/data-selection/components/data-selection/data-selection.html
@@ -25,8 +25,7 @@
                         ng-if="!vm.showTabHeader()"
                         state="vm.state"
                         available-filters="vm.availableFilters"
-                        number-of-records="vm.numberOfRecords"
-                        is-loading="vm.isLoading">
+                        number-of-records="vm.numberOfRecords">
                     </dp-data-selection-header>
 
                     <div ng-if="vm.showContent">

--- a/modules/data-selection/components/data-selection/data-selection.html
+++ b/modules/data-selection/components/data-selection/data-selection.html
@@ -10,9 +10,7 @@
                     <dp-data-selection-available-filters
                         dataset="{{vm.state.dataset}}"
                         available-filters="vm.availableFilters"
-                        active-filters="vm.state.filters"
-                        is-loading="vm.isLoading">
-
+                        active-filters="vm.state.filters">
                     </dp-data-selection-available-filters>
                 </div>
                 <div class="c-data-selection__body"

--- a/modules/data-selection/components/header/header.component.js
+++ b/modules/data-selection/components/header/header.component.js
@@ -7,8 +7,7 @@
             bindings: {
                 state: '<',
                 availableFilters: '<',
-                numberOfRecords: '<',
-                isLoading: '<'
+                numberOfRecords: '<'
             },
             templateUrl: 'modules/data-selection/components/header/header.html',
             controllerAs: 'vm',
@@ -23,29 +22,24 @@
         $scope.$watchGroup([
             'vm.state.dataset',
             'vm.state.view',
-            'vm.numberOfRecords',
-            'vm.isLoading'
+            'vm.numberOfRecords'
         ], setHeader);
 
         function setHeader () {
             const isListView = vm.state.view === 'LIST';
 
-            vm.showHeader = isListView || !vm.isLoading;
             vm.showButtons = vm.state.dataset !== 'catalogus';
-            vm.showTitle = isListView || (!vm.isLoading && vm.numberOfRecords);
+            vm.showTitle = isListView || vm.numberOfRecords;
             vm.showSearchQuery = angular.isString(vm.state.query);
             vm.showTabs = isListView;
-            vm.showNoResultsFound = vm.numberOfRecords === 0 && !vm.isLoading;
-            vm.showActiveFilters = !vm.isLoading &&
-                (Object.keys(vm.state.filters).length || vm.state.geometryFilter.markers.length);
+            vm.showNoResultsFound = vm.numberOfRecords === 0;
+            vm.showActiveFilters = Object.keys(vm.state.filters).length || vm.state.geometryFilter.markers.length;
 
             vm.maxAvailablePages = DATA_SELECTION_CONFIG.datasets[vm.state.dataset].MAX_AVAILABLE_PAGES;
             vm.showMessageMaxPages = vm.maxAvailablePages && vm.state.page > vm.maxAvailablePages;
 
             vm.maxNumberOfClusteredMarkers = DATA_SELECTION_CONFIG.options.MAX_NUMBER_OF_CLUSTERED_MARKERS;
-            vm.showMessageClusteredMarkers = isListView &&
-                !vm.isLoading &&
-                vm.numberOfRecords > vm.maxNumberOfClusteredMarkers;
+            vm.showMessageClusteredMarkers = isListView && vm.numberOfRecords > vm.maxNumberOfClusteredMarkers;
 
             vm.datasetTitle = DATA_SELECTION_CONFIG.datasets[vm.state.dataset].TITLE;
 

--- a/modules/data-selection/components/header/header.component.test.js
+++ b/modules/data-selection/components/header/header.component.test.js
@@ -48,10 +48,6 @@ describe('The dp-data-selection-header', () => {
                 $provide.factory('dpDataSelectionActiveFiltersDirective', () => {
                     return {};
                 });
-
-                $provide.factory('dpLoadingIndicatorDirective', () => {
-                    return {};
-                });
             }
         );
 
@@ -74,8 +70,7 @@ describe('The dp-data-selection-header', () => {
                     description: 'geometryFilter description'
                 }
             },
-            numberOfRecords: null,
-            isLoading: true
+            numberOfRecords: null
         };
 
         mockedInputList = {
@@ -90,8 +85,7 @@ describe('The dp-data-selection-header', () => {
                     description: 'geometryFilter description'
                 }
             },
-            numberOfRecords: null,
-            isLoading: true
+            numberOfRecords: null
         };
 
         mockedInputCards = {
@@ -107,8 +101,7 @@ describe('The dp-data-selection-header', () => {
                 },
                 page: 1
             },
-            numberOfRecords: null,
-            isLoading: true
+            numberOfRecords: null
         };
 
         spyOn(store, 'dispatch');
@@ -119,13 +112,11 @@ describe('The dp-data-selection-header', () => {
         element.setAttribute('state', 'state');
         element.setAttribute('available-filters', 'availableFilters');
         element.setAttribute('number-of-records', 'numberOfRecords');
-        element.setAttribute('is-loading', 'isLoading');
 
         const scope = $rootScope.$new();
         scope.state = mockedInput.state;
         scope.availableFilters = {};
         scope.numberOfRecords = mockedInput.numberOfRecords;
-        scope.isLoading = mockedInput.isLoading;
 
         const compiledComponent = $compile(element)(scope);
         scope.$apply();
@@ -133,39 +124,18 @@ describe('The dp-data-selection-header', () => {
         return compiledComponent;
     }
 
-    describe('The buttons (download and toggle view) are only available in TABLE and LIST view', () => {
-        it('is only visible in TABLE view when the loading is done', () => {
-            // When loading
-            mockedInputTable.isLoading = true;
-            component = getComponent(mockedInputTable);
-            expect(component.find('.qa-buttons').length).toBe(0);
-
-            // When loading is finished
-            mockedInputTable.isLoading = false;
+    describe('The buttons (download and toggle view)', () => {
+        it('are available in the TABLE view', () => {
             component = getComponent(mockedInputTable);
             expect(component.find('.qa-buttons').length).toBe(1);
         });
 
-        it('is always visible in LIST view', () => {
-            // When loading
-            mockedInputList.isLoading = true;
-            component = getComponent(mockedInputList);
-            expect(component.find('.qa-buttons').length).toBe(1);
-
-            // When loading is finished
-            mockedInputList.isLoading = false;
+        it('are available in the LIST view', () => {
             component = getComponent(mockedInputList);
             expect(component.find('.qa-buttons').length).toBe(1);
         });
 
-        it('is never visible in CARDS view', () => {
-            // When loading
-            mockedInputCards.isLoading = true;
-            component = getComponent(mockedInputCards);
-            expect(component.find('.qa-buttons').length).toBe(0);
-
-            // When loading is finished
-            mockedInputCards.isLoading = false;
+        it('are never available in the CARDS view', () => {
             component = getComponent(mockedInputCards);
             expect(component.find('.qa-buttons').length).toBe(0);
         });
@@ -174,7 +144,6 @@ describe('The dp-data-selection-header', () => {
     describe('the header title', function () {
         it('in TABLE view shows the name followed by the number of results', () => {
             mockedInputTable.numberOfRecords = 1234;
-            mockedInputTable.isLoading = false;
             component = getComponent(mockedInputTable);
 
             // Avec thousand separator
@@ -182,8 +151,6 @@ describe('The dp-data-selection-header', () => {
         });
 
         it('in CARDS view shows the number of results followed by the word \'dataset(s)\'', () => {
-            mockedInputCards.isLoading = false;
-
             // Singular
             mockedInputCards.numberOfRecords = 1;
             component = getComponent(mockedInputCards);
@@ -216,7 +183,6 @@ describe('The dp-data-selection-header', () => {
     it('shows the search query in the header', () => {
         // When there is a query
         mockedInputCards.state.query = 'parkeren';
-        mockedInputCards.isLoading = false; // The whole header isn't shown when loading the CARDS view
 
         component = getComponent(mockedInputCards);
         expect(component.find('.qa-search-query').text()).toBe('met "parkeren"');
@@ -233,172 +199,114 @@ describe('The dp-data-selection-header', () => {
         });
 
         describe(`in ${viewName} view`, () => {
-            describe('when loading', () => {
-                it('potentially shows the max pages message', () => {
-                    // Don't show the message
-                    mockedViewInput.state.page = 50;
-                    component = getComponent(mockedViewInput);
-                    expect(component.find('.qa-message-max-pages').length).toBe(0);
-
-                    // Show the message
-                    mockedViewInput.state.page = 51;
-                    component = getComponent(mockedViewInput);
-                    expect(component.find('.qa-message-max-pages').length).toBe(1);
-                });
-
-                it('doesn\'t show the buttons, title, tabs, no results found and clustered markers message', () => {
-                    component = getComponent(mockedViewInput);
-
-                    expect(component.find('.qa-buttons').length).toBe(0);
-                    expect(component.find('.qa-title').length).toBe(0);
-                    expect(component.find('.qa-tabs').length).toBe(0);
-                    expect(component.find('.qa-no-results-found').length).toBe(0);
-                    expect(component.find('.qa-clustered-markers').length).toBe(0);
-                });
+            beforeEach(() => {
+                mockedViewInput.numberOfRecords = 1234;
             });
 
-            describe('when the loading is finished', () => {
-                beforeEach(() => {
-                    mockedViewInput.numberOfRecords = 1234;
-                    mockedViewInput.isLoading = false;
-                });
+            it('shows the title', () => {
+                component = getComponent(mockedViewInput);
 
-                it('shows the title', () => {
-                    component = getComponent(mockedViewInput);
+                expect(component.find('.qa-title').length).toBe(1);
+            });
 
-                    expect(component.find('.qa-title').length).toBe(1);
-                });
+            it('potentially shows the no results found message (instead of the title)', function () {
+                // When there are results
+                mockedViewInput.numberOfRecords = 1;
+                component = getComponent(mockedViewInput);
 
-                it('potentially shows the no results found message (instead of the title)', function () {
-                    // When there are results
-                    mockedViewInput.numberOfRecords = 1;
-                    component = getComponent(mockedViewInput);
+                expect(component.find('.qa-title').length).toBe(1);
+                expect(component.find('.qa-no-results-found').length).toBe(0);
 
-                    expect(component.find('.qa-title').length).toBe(1);
-                    expect(component.find('.qa-no-results-found').length).toBe(0);
+                // When there are no results
+                mockedViewInput.numberOfRecords = 0;
+                component = getComponent(mockedViewInput);
 
-                    // When there are no results
-                    mockedViewInput.numberOfRecords = 0;
-                    component = getComponent(mockedViewInput);
+                expect(component.find('.qa-title').length).toBe(0);
+                expect(component.find('h2.qa-no-results-found').length).toBe(1);
+                // Make sure it isn't shown as a p as well
+                expect(component.find('p.qa-no-results-found').length).toBe(0);
+            });
 
-                    expect(component.find('.qa-title').length).toBe(0);
-                    expect(component.find('h2.qa-no-results-found').length).toBe(1);
-                    // Make sure it isn't shown as a p as well
-                    expect(component.find('p.qa-no-results-found').length).toBe(0);
-                });
+            it('doesn\'t show tabs', function () {
+                component = getComponent(mockedViewInput);
 
-                it('doesn\'t show tabs', function () {
-                    component = getComponent(mockedViewInput);
+                expect(component.find('.qa-tabs').length).toBe(0);
+            });
 
-                    expect(component.find('.qa-tabs').length).toBe(0);
-                });
+            it('potentially shows the max pages message', () => {
+                // Don't show the message
+                mockedViewInput.state.page = 50;
+                component = getComponent(mockedViewInput);
+                expect(component.find('.qa-message-max-pages').length).toBe(0);
 
-                it('potentially shows the max pages message', () => {
-                    // Don't show the message
-                    mockedViewInput.state.page = 50;
-                    component = getComponent(mockedViewInput);
-                    expect(component.find('.qa-message-max-pages').length).toBe(0);
+                // Show the message
+                mockedViewInput.state.page = 51;
+                component = getComponent(mockedViewInput);
+                expect(component.find('.qa-message-max-pages').length).toBe(1);
+            });
 
-                    // Show the message
-                    mockedViewInput.state.page = 51;
-                    component = getComponent(mockedViewInput);
-                    expect(component.find('.qa-message-max-pages').length).toBe(1);
-                });
-
-                it('doesn\'t show the clustered markers message', () => {
-                    mockedViewInput.numberOfRecords = 1001;
-                    component = getComponent(mockedViewInput);
-                    expect(component.find('.qa-message-clustered-markers').length).toBe(0);
-                });
+            it('doesn\'t show the clustered markers message', () => {
+                mockedViewInput.numberOfRecords = 1001;
+                component = getComponent(mockedViewInput);
+                expect(component.find('.qa-message-clustered-markers').length).toBe(0);
             });
         });
     });
 
     describe('in LIST view', () => {
-        describe('when loading', () => {
-            beforeEach(function () {
-                mockedInputList.isLoading = true;
-            });
+        it('shows the buttons and title', () => {
+            component = getComponent(mockedInputList);
 
-            it('shows the buttons and title', () => {
-                component = getComponent(mockedInputList);
-
-                expect(component.find('.qa-buttons').length).toBe(1);
-                expect(component.find('.qa-title').length).toBe(1);
-            });
-
-            it('shows the tabs', function () {
-                component = getComponent(mockedInputList);
-
-                expect(component.find('.qa-tabs').length).toBe(1);
-            });
-
-            it('potentially shows the max pages message', () => {
-                // Don't show the message
-                mockedInputList.state.page = 50;
-                component = getComponent(mockedInputList);
-                expect(component.find('.qa-message-max-pages').length).toBe(0);
-
-                // Show the message
-                mockedInputList.state.page = 51;
-                component = getComponent(mockedInputList);
-                expect(component.find('.qa-message-max-pages').length).toBe(1);
-            });
-
-            it('doesn\'t show the no results found and clustered markers message', () => {
-                component = getComponent(mockedInputList);
-
-                expect(component.find('.qa-no-results-found').length).toBe(0);
-                expect(component.find('.qa-clustered-markers').length).toBe(0);
-            });
+            expect(component.find('.qa-buttons').length).toBe(1);
+            expect(component.find('.qa-title').length).toBe(1);
         });
 
-        describe('when the loading is finished', () => {
-            beforeEach(function () {
-                mockedInputList.isLoading = false;
-            });
+        it('shows the tabs', function () {
+            component = getComponent(mockedInputList);
 
-            it('potentially shows the no results found message', function () {
-                // Don't show the message
-                mockedInputList.numberOfRecords = 1234;
-                component = getComponent(mockedInputList);
-                expect(component.find('.qa-no-results-found').length).toBe(0);
+            expect(component.find('.qa-tabs').length).toBe(1);
+        });
 
-                // Show the message
-                mockedInputList.numberOfRecords = 0;
-                component = getComponent(mockedInputList);
-                expect(component.find('p.qa-no-results-found').length).toBe(1);
-                // Make sure it isn't shown as a h2 as well
-                expect(component.find('h2.qa-no-results-found').length).toBe(0);
-            });
+        it('potentially shows the no results found message', function () {
+            // Don't show the message
+            mockedInputList.numberOfRecords = 1234;
+            component = getComponent(mockedInputList);
+            expect(component.find('.qa-no-results-found').length).toBe(0);
 
-            it('potentially shows the max pages message', () => {
-                // Don't show the message
-                mockedInputList.state.page = 50;
-                component = getComponent(mockedInputList);
-                expect(component.find('.qa-message-max-pages').length).toBe(0);
+            // Show the message
+            mockedInputList.numberOfRecords = 0;
+            component = getComponent(mockedInputList);
+            expect(component.find('p.qa-no-results-found').length).toBe(1);
+            // Make sure it isn't shown as a h2 as well
+            expect(component.find('h2.qa-no-results-found').length).toBe(0);
+        });
 
-                // Show the message
-                mockedInputList.state.page = 51;
-                component = getComponent(mockedInputList);
-                expect(component.find('.qa-message-max-pages').length).toBe(1);
-            });
+        it('potentially shows the max pages message', () => {
+            // Don't show the message
+            mockedInputList.state.page = 50;
+            component = getComponent(mockedInputList);
+            expect(component.find('.qa-message-max-pages').length).toBe(0);
 
-            it('potentially shows the clustered markers message', () => {
-                // Don't show the message
-                mockedInputList.numberOfRecords = 1000;
-                component = getComponent(mockedInputList);
-                expect(component.find('.qa-message-clustered-markers').length).toBe(0);
+            // Show the message
+            mockedInputList.state.page = 51;
+            component = getComponent(mockedInputList);
+            expect(component.find('.qa-message-max-pages').length).toBe(1);
+        });
 
-                // Show the message
-                mockedInputList.numberOfRecords = 1001;
-                component = getComponent(mockedInputList);
-                expect(component.find('.qa-message-clustered-markers').length).toBe(1);
-            });
+        it('potentially shows the clustered markers message', () => {
+            // Don't show the message
+            mockedInputList.numberOfRecords = 1000;
+            component = getComponent(mockedInputList);
+            expect(component.find('.qa-message-clustered-markers').length).toBe(0);
+
+            // Show the message
+            mockedInputList.numberOfRecords = 1001;
+            component = getComponent(mockedInputList);
+            expect(component.find('.qa-message-clustered-markers').length).toBe(1);
         });
     });
 
-    it('the active filters are only shown when the loading is finished and at least one filter is active', () => {
+    it('the active filters are only shown when at least one filter is active', () => {
         const mockedInput = {
             TABLE: mockedInputTable,
             LIST: mockedInputList,
@@ -407,13 +315,6 @@ describe('The dp-data-selection-header', () => {
 
         // With one active filter
         ['TABLE', 'LIST', 'CARDS'].forEach(viewName => {
-            // When loading
-            mockedInput[viewName].isLoading = true;
-            component = getComponent(mockedInput[viewName]);
-            expect(component.find('.qa-active-filters').length).toBe(0);
-
-            // When loading is finished
-            mockedInput[viewName].isLoading = false;
             component = getComponent(mockedInput[viewName]);
             expect(component.find('.qa-active-filters').length).toBe(1);
         });
@@ -424,8 +325,6 @@ describe('The dp-data-selection-header', () => {
         mockedInput.CARDS.state.filters = {};
 
         ['TABLE', 'LIST', 'CARDS'].forEach(viewName => {
-            // When loading is finished
-            mockedInput[viewName].isLoading = false;
             component = getComponent(mockedInput[viewName]);
             expect(component.find('.qa-active-filters').length).toBe(0);
         });
@@ -434,7 +333,6 @@ describe('The dp-data-selection-header', () => {
     it('the messages about MAX_PAGES and MAX_CLUSTERED_MARKERS use DATA_SELECTION_CONFIG', () => {
         mockedInputList.state.page = 51;
         mockedInputList.numberOfRecords = 1001;
-        mockedInputList.isLoading = false;
 
         component = getComponent(mockedInputList);
 
@@ -448,7 +346,7 @@ describe('The dp-data-selection-header', () => {
             component = getComponent(mockedInputList);
 
             expect(component.find('.qa-tabs li:nth-child(1)').text().trim()).toBe('BAG Adressen');
-            expect(component.find('.qa-tabs li:nth-child(2)').text().trim()).toBe('HR Vestigingen');
+            expect(component.find('.qa-tabs li:nth-child(2)').text().trim()).toContain('HR Vestigingen');
         });
 
         it('inactive tabs are links to the first page of other datasets', () => {
@@ -478,16 +376,8 @@ describe('The dp-data-selection-header', () => {
         });
 
         it('shows the number of results in the tab heading for the active dataset', () => {
-            // It only shows the title while loading
-            mockedInputList.isLoading = true;
-            component = getComponent(mockedInputList);
-
-            expect(component.find('.qa-tabs li:nth-child(1)').text().trim()).toBe('BAG Adressen');
-            expect(component.find('.qa-tabs li:nth-child(2)').text().trim()).toBe('HR Vestigingen');
-
-            // It shows the number of results when loading has finished for the active tab only
+            // It shows the number of results for the active tab only
             mockedInputList.numberOfRecords = 12345;
-            mockedInputList.isLoading = false;
             component = getComponent(mockedInputList);
 
             expect(component.find('.qa-tabs li:nth-child(1)').text().trim()).toBe('BAG Adressen');

--- a/modules/data-selection/components/header/header.html
+++ b/modules/data-selection/components/header/header.html
@@ -1,4 +1,4 @@
-<div ng-if="vm.showHeader" ng-class="{
+<div ng-class="{
         'u-margin__bottom--3': vm.showTabs || !vm.showActiveFilters,
         'u-margin__bottom--1-5': !(vm.showTabs || !vm.showActiveFilters)
     }">
@@ -33,7 +33,7 @@
 
             <span ng-if="tab.isActive" class="o-tabs__tab o-tabs__tab--active">
                 {{tab.title}}
-                <span ng-if="!vm.isLoading && tab.isActive">({{vm.numberOfRecords | number}})</span>
+                <span ng-if="tab.isActive">({{vm.numberOfRecords | number}})</span>
             </span>
         </li>
     </ul>
@@ -50,7 +50,6 @@
 
 <p ng-if="vm.showNoResultsFound && vm.showTabs" class="qa-no-results-found">Geen resultaten gevonden</p>
 
-<dp-loading-indicator is-loading="vm.isLoading" use-delay="false" show-inline="true"></dp-loading-indicator>
 
 <dp-panel ng-if="vm.showMessageMaxPages" is-panel-visible="true" type="warning" can-close="true">
     <div class="qa-message-max-pages">


### PR DESCRIPTION
isLoading conditions removed for components that are only nested in the data-selection component inside the `ng-if="!vm.isLoading"` block.