### PR TITLE
module-getter - enforce to reference modules with the getter syntax c…

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
         "eol-last": "error",            //require or disallow newline at the end of files
         "no-shadow": "error",           // disallow variable declarations shadowing outer scope variables
         "angular/json-functions": "error",    // use angular.fromJson/toJson instead of JSON.parse and JSON.stringify
+        "angular/module-getter": "off", // When using a module, avoid variable, use chaining with the getter syntax
         "spaced-comment": "error",      // enforce consistent spacing after the // or /* in a comment
         "indent": [                     // enforce consistent indentation
             "error",
@@ -144,8 +145,6 @@ module.exports = {
         "no-new-wrappers": "error",         // disallow new operators with the String, Number, and Boolean objects
         "no-invalid-this": "error",         // disallow this keywords outside of classes or class-like objects
         "require-yield": "error"            // require generator functions to contain yield
-
-
     },
     "plugins": [
         "standard",                         // Shareable config for JavaScript Standard Style


### PR DESCRIPTION
…auses errors in the grunt files