### PR TITLE
Fixed showing more monuments after clicking on 'Toon meer' monuments on

### DIFF
--- a/modules/search-results/components/search-results/search-results.html
+++ b/modules/search-results/components/search-results/search-results.html
@@ -63,6 +63,7 @@
                 <dp-search-results-header
                     number-of-results="vm.numberOfResults"
                     query="{{vm.query}}"
+                    location="vm.location"
                     category="{{vm.category}}">
                 </dp-search-results-header>
 

--- a/modules/search-results/services/search-title/search-title.factory.js
+++ b/modules/search-results/services/search-title/search-title.factory.js
@@ -12,7 +12,7 @@
         };
 
         function getTitleData (numberOfResults, query, location, category) {
-            const categoryName = getCategoryName(category),
+            const categoryName = getCategoryName(category, query, location),
                 title = getTitle(categoryName, numberOfResults),
                 subTitle = getSubTitle(query, location);
 
@@ -28,15 +28,17 @@
             }
         }
 
-        function getCategoryName (category) {
-            let categoryName = null;
+        function getCategoryName (categorySlug, query, location) {
+            const config = query
+                ? SEARCH_CONFIG.QUERY_ENDPOINTS
+                : SEARCH_CONFIG.COORDINATES_HIERARCHY;
+            const categories = categorySlug
+                ? config.filter(endpoint => endpoint.slug === categorySlug)
+                : null;
 
-            if (category) {
-                categoryName = SEARCH_CONFIG.QUERY_ENDPOINTS.filter(
-                    endpoint => endpoint.slug === category)[0].label_plural;
-            }
-
-            return categoryName;
+            return categories && categories.length
+                ? categories[0].label_plural
+                : null;
         }
 
         function getTitle (categoryName, numberOfResults) {

--- a/modules/search-results/services/search-title/search-title.factory.js
+++ b/modules/search-results/services/search-title/search-title.factory.js
@@ -28,6 +28,20 @@
             }
         }
 
+        /**
+         * Retrieves the name of the category based on the categorySlug
+         * provided.
+         *
+         * When searched by query the name will be retrieved from the
+         * QUERY_ENDPOINTS. When searched by location the name will be
+         * retrieved from the COORDINATES_HIERARCHY.
+         *
+         * @param {string} categorySlug The slug of the category to get the
+         * name for.
+         * @param {string} query Truthy when seached by query.
+         * @param {number[]} location Truthy when searched by location.
+         * @return {?string} The name of the category or null.
+         */
         function getCategoryName (categorySlug, query, location) {
             const config = query
                 ? SEARCH_CONFIG.QUERY_ENDPOINTS

--- a/modules/search-results/services/search-title/search-title.factory.test.js
+++ b/modules/search-results/services/search-title/search-title.factory.test.js
@@ -18,6 +18,16 @@ describe('The search title factory', function () {
                             label_plural: 'Adressen',
                             uri: 'path/to/adres/'
                         }
+                    ],
+                    COORDINATES_HIERARCHY: [
+                        {
+                            slug: 'monument',
+                            label_singular: 'Monument',
+                            label_plural: 'Monumenten',
+                            features: [
+                                'monumenten/monument'
+                            ]
+                        }
                     ]
                 });
 
@@ -60,11 +70,17 @@ describe('The search title factory', function () {
         expect(titleData.subTitle).toContain('X, Y (52.123, 4.789)');
     });
 
-    it('shows only the query in the title', function () {
+    it('can show category and query', function () {
         var titleData = searchTitle.getTitleData(47, 'westerpark', null, 'adres');
 
-        // The category name will be converted to lowercase
         expect(titleData.title).toBe('Adressen met \'westerpark\'');
+        expect(titleData.subTitle).toBeUndefined();
+    });
+
+    it('can show category and location', function () {
+        var titleData = searchTitle.getTitleData(47, null, [52.123, 4.789], 'monument');
+
+        expect(titleData.title).toBe('Monumenten met locatie X, Y (52.123, 4.789)');
         expect(titleData.subTitle).toBeUndefined();
     });
 


### PR DESCRIPTION
a search results page after clicking on the map. Page title and
document title show correctly 'Monumenten' and the location.