### PR TITLE
Recover from error response, 404 is acceptable

### DIFF
--- a/modules/shared/components/straatbeeld-thumbnail/straatbeeld-thumbnail.component.js
+++ b/modules/shared/components/straatbeeld-thumbnail/straatbeeld-thumbnail.component.js
@@ -12,9 +12,9 @@
             controllerAs: 'vm'
         });
 
-    DpStraatbeeldThumbnailController.$inject = ['$scope', 'sharedConfig', 'api', 'userSettings'];
+    DpStraatbeeldThumbnailController.$inject = ['$q', '$scope', 'sharedConfig', 'api', 'userSettings'];
 
-    function DpStraatbeeldThumbnailController ($scope, sharedConfig, api, userSettings) {
+    function DpStraatbeeldThumbnailController ($q, $scope, sharedConfig, api, userSettings) {
         var vm = this,
             imageUrl,
             heading,
@@ -54,6 +54,13 @@
                     vm.hasThumbnail = false;
                 }
 
+                vm.isLoading = false;
+            }, (rejection) => {
+                if (rejection.status === 404) {
+                    rejection.errorHandled = true;
+                }
+
+                vm.hasThumbnail = false;
                 vm.isLoading = false;
             });
         }

--- a/modules/shared/services/http-error-registrar/http-error-registrar.factory.js
+++ b/modules/shared/services/http-error-registrar/http-error-registrar.factory.js
@@ -6,9 +6,9 @@
         .factory('httpErrorRegistrar', httpErrorRegistrarFactory)
         .config($httpProvider => $httpProvider.interceptors.push('httpErrorRegistrar'));
 
-    httpErrorRegistrarFactory.inject = ['$rootScope', '$window', '$q', 'httpStatus'];
+    httpErrorRegistrarFactory.inject = ['$rootScope', '$window', '$q', '$timeout', 'httpStatus'];
 
-    function httpErrorRegistrarFactory ($rootScope, $window, $q, httpStatus) {
+    function httpErrorRegistrarFactory ($rootScope, $window, $q, $timeout, httpStatus) {
         $window.addEventListener('error', function (e) {
             if (e.target && e.target.src) {
                 // URL load error
@@ -29,31 +29,40 @@
         }
 
         function responseError (response) {
-            // register server errors (5xx) and client errors (4xx)
-            let isServerError = 500 <= response.status && response.status <= 599;
-            const isClientError = 400 <= response.status && response.status <= 499;
+            // Give the local response handler the time to handle an error
+            // itself. See:
+            // https://stackoverflow.com/questions/33605486/
+            // handle-angular-http-errors-locally-with-fallback-to-global-error-handling
+            $timeout(() => {
+                // Check if the error has already been handled locally
+                const errorHandled = response.errorHandled;
 
-            if (response.status <= 0) {
-                // Check if the error is due to a cancelled http request
-                if (response.config.timeout && angular.isFunction(response.config.timeout.then)) {
-                    response.config.timeout.then(
-                        angular.noop,   // request has been cancelled by resolving the timeout
-                        registerServerError // Abnormal end of request
-                    );
-                } else {
-                    isServerError = true;
+                // register server errors (5xx) and client errors (4xx)
+                let isServerError = !errorHandled && 500 <= response.status && response.status <= 599;
+                const isClientError = !errorHandled && 400 <= response.status && response.status <= 499;
+
+                if (response.status <= 0) {
+                    // Check if the error is due to a cancelled http request
+                    if (response.config.timeout && angular.isFunction(response.config.timeout.then)) {
+                        response.config.timeout.then(
+                            angular.noop,   // request has been cancelled by resolving the timeout
+                            registerServerError // Abnormal end of request
+                        );
+                    } else {
+                        isServerError = true;
+                    }
                 }
-            }
 
-            if (isServerError) {
-                registerServerError();
-            } else if (isClientError) {
-                if (response && response.data && response.data.detail === 'Not found.') {
-                    registerNotFoundError();
-                } else {
+                if (isServerError) {
                     registerServerError();
+                } else if (isClientError) {
+                    if (response && response.data && response.data.detail === 'Not found.') {
+                        registerNotFoundError();
+                    } else {
+                        registerServerError();
+                    }
                 }
-            }
+            });
 
             return $q.reject(response);
         }

--- a/modules/shared/services/http-error-registrar/http-error-registrar.factory.test.js
+++ b/modules/shared/services/http-error-registrar/http-error-registrar.factory.test.js
@@ -7,6 +7,7 @@ describe('The http error registrar', function () {
     let $httpBackend,
         $http,
         $rootScope,
+        $timeout,
         mockedData,
         onError,
         callbackCalled;
@@ -27,10 +28,11 @@ describe('The http error registrar', function () {
             $provide.value('$window', window);
         });
 
-        angular.mock.inject(function (_$httpBackend_, _$http_, _$rootScope_) {
+        angular.mock.inject(function (_$httpBackend_, _$http_, _$rootScope_, _$timeout_) {
             $httpBackend = _$httpBackend_;
             $http = _$http_;
             $rootScope = _$rootScope_;
+            $timeout = _$timeout_;
         });
 
         mockedData = {
@@ -67,11 +69,13 @@ describe('The http error registrar', function () {
             .then(data => {
                 expect(data.data).toEqual(mockedData);
                 expect(data.status).toBe(200);
-                expect(httpStatus.registerError).not.toHaveBeenCalled();
                 callbackCalled = true;
             });
 
         $httpBackend.flush();
+        $timeout.flush();
+
+        expect(httpStatus.registerError).not.toHaveBeenCalled();
         expect(callbackCalled).toBe(true);
     });
 
@@ -81,11 +85,13 @@ describe('The http error registrar', function () {
             .catch(data => {
                 expect(data.data).toEqual(mockedData);
                 expect(data.status).toBe(300);
-                expect(httpStatus.registerError).not.toHaveBeenCalled();
                 callbackCalled = true;
             });
 
         $httpBackend.flush();
+        $timeout.flush();
+
+        expect(httpStatus.registerError).not.toHaveBeenCalled();
         expect(callbackCalled).toBe(true);
     });
 
@@ -95,11 +101,13 @@ describe('The http error registrar', function () {
             .catch(data => {
                 expect(data.data).toEqual(mockedData);
                 expect(data.status).toBe(400);
-                expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.SERVER_ERROR);
                 callbackCalled = true;
             });
 
         $httpBackend.flush();
+        $timeout.flush();
+
+        expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.SERVER_ERROR);
         expect(callbackCalled).toBe(true);
     });
 
@@ -117,11 +125,13 @@ describe('The http error registrar', function () {
             .catch(data => {
                 expect(data.data).toEqual(mockedData);
                 expect(data.status).toBe(404);
-                expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.NOT_FOUND_ERROR);
                 callbackCalled = true;
             });
 
         $httpBackend.flush();
+        $timeout.flush();
+
+        expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.NOT_FOUND_ERROR);
         expect(callbackCalled).toBe(true);
     });
 
@@ -137,11 +147,13 @@ describe('The http error registrar', function () {
             .catch(data => {
                 expect(data.data).toEqual(mockedData);
                 expect(data.status).toBe(404);
-                expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.SERVER_ERROR);
                 callbackCalled = true;
             });
 
         $httpBackend.flush();
+        $timeout.flush();
+
+        expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.SERVER_ERROR);
         expect(callbackCalled).toBe(true);
     });
 
@@ -151,11 +163,13 @@ describe('The http error registrar', function () {
             .catch(data => {
                 expect(data.data).toEqual(mockedData);
                 expect(data.status).toBe(500);
-                expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.SERVER_ERROR);
                 callbackCalled = true;
             });
 
         $httpBackend.flush();
+        $timeout.flush();
+
+        expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.SERVER_ERROR);
         expect(callbackCalled).toBe(true);
     });
 
@@ -182,11 +196,13 @@ describe('The http error registrar', function () {
         }).catch(data => {
             expect(data.data).toEqual(mockedData);
             expect(data.status).toBe(-1);
-            expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.SERVER_ERROR);
             callbackCalled = true;
         });
 
         $httpBackend.flush();
+        $timeout.flush();
+
+        expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.SERVER_ERROR);
         expect(callbackCalled).toBe(true);
     });
 
@@ -204,11 +220,13 @@ describe('The http error registrar', function () {
             .catch(data => {
                 expect(data.data).toEqual(mockedData);
                 expect(data.status).toBe(-1);
-                expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.SERVER_ERROR);
                 callbackCalled = true;
             });
 
         $httpBackend.flush();
+        $timeout.flush();
+
+        expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.SERVER_ERROR);
         expect(callbackCalled).toBe(true);
     });
 
@@ -222,11 +240,60 @@ describe('The http error registrar', function () {
             .catch(data => {
                 expect(data.data).toEqual(mockedData);
                 expect(data.status).toBe(-1);
-                expect(httpStatus.registerError).not.toHaveBeenCalled();
                 callbackCalled = true;
             });
 
         $httpBackend.flush();
+        $timeout.flush();
+
+        expect(httpStatus.registerError).not.toHaveBeenCalled();
+        expect(callbackCalled).toBe(true);
+    });
+
+    it('calls the local error handler before the global one', function () {
+        mockedData = {};
+
+        $httpBackend
+            .whenGET('http://api-domain.amsterdam.nl/404')
+            .respond(404, mockedData);
+
+        $http
+            .get('http://api-domain.amsterdam.nl/404')
+            .catch(data => {
+                callbackCalled = true;
+            });
+
+        expect(callbackCalled).toBe(false);
+
+        $httpBackend.flush();
+
+        expect(httpStatus.registerError).not.toHaveBeenCalled();
+        expect(callbackCalled).toBe(true);
+
+        $timeout.flush();
+
+        expect(httpStatus.registerError).toHaveBeenCalledWith(httpStatus.SERVER_ERROR);
+    });
+
+    it('does not handle an error that has already been handled locally', function () {
+        mockedData = {};
+
+        $httpBackend
+            .whenGET('http://api-domain.amsterdam.nl/404')
+            .respond(404, mockedData);
+
+        $http
+            .get('http://api-domain.amsterdam.nl/404')
+            .catch(data => {
+                // Mark the error to be handled
+                data.errorHandled = true;
+                callbackCalled = true;
+            });
+
+        $httpBackend.flush();
+        $timeout.flush();
+
+        expect(httpStatus.registerError).not.toHaveBeenCalled();
         expect(callbackCalled).toBe(true);
     });
 });


### PR DESCRIPTION
The straatbeeld-thumbnail component handles error responses. A 404 is accepted.
A change was needed to the http-error-registrar to make local error handlers be executed before the global one and give the local error handlers the ability to recover (make the global error handler ignore it).