### PR TITLE
Fix page breaks tg-3768

### DIFF
--- a/modules/shared/styles/layout/_grid.scss
+++ b/modules/shared/styles/layout/_grid.scss
@@ -44,7 +44,10 @@
     [class*="u-col-"] {
       position: relative;
       min-height: 1px;
-      float: left;
+
+      &:not([class*="12"]) {
+        float: left;
+      }
     }
 
     @media (min-width: $breakpoint-sm) {


### PR DESCRIPTION
Do not float columns of size 12. Not necessary, and this fixes page breaking issues when printing.